### PR TITLE
Fix for install from pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include common.py


### PR DESCRIPTION
The current version of scikits.odes is missing the common.py file, this adds it to the MANIFEST.in so that it's included in the sdist.
