### PR TITLE
Fix importing of cvode to work on py3.

### DIFF
--- a/scikits/odes/ode.py
+++ b/scikits/odes/ode.py
@@ -302,7 +302,7 @@ def find_ode_integrator(name):
     if not ode.LOADED:
         ## cvode
         try:
-            from sundials import cvode
+            from .sundials import cvode
             OdeBase.integrator_classes.append(cvode.CVODE)
         except ValueError as msg:
             print('Could not load CVODE solver', msg)


### PR DESCRIPTION
Probably should have added pull request when I wrote this, this allows cvode to be used on python 3.
