### PR TITLE
Fixed path in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include common.py scikits/odes/sundials/sundials_auxiliary.c
+include common.py scikits/odes/sundials/sundials_auxiliary/sundials_auxiliary.c
 recursive-include scikits *.pyx *.pxd *.pyf


### PR DESCRIPTION
sundials_auxiliary.c wasn't included in the sdist, this fixes the path.
