### PR TITLE
Add relative imports to cython files

### DIFF
--- a/scikits/odes/sundials/c_cvode.pxd
+++ b/scikits/odes/sundials/c_cvode.pxd
@@ -1,4 +1,4 @@
-from c_sundials cimport *
+from .c_sundials cimport *
 from libc.stdio cimport FILE
 
 cdef extern from "cvode/cvode.h":

--- a/scikits/odes/sundials/c_ida.pxd
+++ b/scikits/odes/sundials/c_ida.pxd
@@ -1,4 +1,4 @@
-from c_sundials cimport *
+from .c_sundials cimport *
 from libc.stdio cimport FILE
 
 cdef extern from "ida/ida.h":

--- a/scikits/odes/sundials/common_defs.pxd
+++ b/scikits/odes/sundials/common_defs.pxd
@@ -1,5 +1,5 @@
 cimport numpy as np
-from c_sundials cimport N_Vector, DlsMat
+from .c_sundials cimport N_Vector, DlsMat
 
 ctypedef np.float_t DTYPE_t
 

--- a/scikits/odes/sundials/common_defs.pyx
+++ b/scikits/odes/sundials/common_defs.pyx
@@ -1,7 +1,7 @@
 import numpy as np
 cimport numpy as np
 import inspect
-from c_sundials cimport (N_Vector, nv_content_data_s, nv_content_s, nv_length_s,
+from .c_sundials cimport (N_Vector, nv_content_data_s, nv_content_s, nv_length_s,
                         nv_data_s, get_nv_ith_s, set_nv_ith_s, get_dense_col,
                         get_dense_N, set_dense_element,
                         DlsMat)

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -1,5 +1,5 @@
 cimport numpy as np
-from c_sundials cimport N_Vector, realtype
+from .c_sundials cimport N_Vector, realtype
 
 ctypedef np.float_t DTYPE_t
 

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -3,9 +3,9 @@ import inspect
 import numpy as np
 cimport numpy as np
 
-from c_sundials cimport realtype, N_Vector
-from c_cvode cimport *
-from common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
+from .c_sundials cimport realtype, N_Vector
+from .c_cvode cimport *
+from .common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
 
 # TODO: parallel implementation: N_VectorParallel
 # TODO: linsolvers: check the output value for errors

--- a/scikits/odes/sundials/ida.pxd
+++ b/scikits/odes/sundials/ida.pxd
@@ -1,5 +1,5 @@
 cimport numpy as np
-from c_sundials cimport N_Vector, realtype
+from .c_sundials cimport N_Vector, realtype
 
 ctypedef np.float_t DTYPE_t
 

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -3,9 +3,9 @@ import inspect
 import numpy as np
 cimport numpy as np
 
-from c_sundials cimport realtype, N_Vector
-from c_ida cimport *
-from common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
+from .c_sundials cimport realtype, N_Vector
+from .c_ida cimport *
+from .common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
 
 # TODO: parallel implementation: N_VectorParallel
 # TODO: linsolvers: check the output value for errors


### PR DESCRIPTION
It appears in newer versions of cython, if cython is told to produce python 3 compatible code, then it uses the new style relative imports. This adds them (and doesn't break python 2).
