### PR TITLE
Cvode: Add jac_times_vecfn option

### DIFF
--- a/docs/src/examples/ode/simpleoscillator_prec.py
+++ b/docs/src/examples/ode/simpleoscillator_prec.py
@@ -21,6 +21,10 @@ def prec_solvefn(t, y, r, z, gamma, delta, lr):
     z[0] =               r[0] + gamma * r[1]
     z[1] = - gamma*k/m * r[0] +         r[1]
 
+def jac_times_vecfn(v, Jv, t, y, user_data):
+    Jv[0] = v[1]
+    Jv[1] = -k/m * v[0] 
+
 #define function for the right-hand-side equations which has specific signature
 def rhseqn(t, x, xdot):
     """ we create rhs equations for the problem"""
@@ -29,7 +33,7 @@ def rhseqn(t, x, xdot):
     
 #instantiate the solver
 from scikits.odes import ode
-solver = ode('cvode', rhseqn, linsolver='spbcg', precond_type='left', prec_solvefn = prec_solvefn)
+solver = ode('cvode', rhseqn, linsolver='spbcg', precond_type='left', prec_solvefn=prec_solvefn, jac_times_vecfn=jac_times_vecfn)
 #obtain solution at a required time
 result = solver.solve([0., 1., 2.], initx)
 

--- a/docs/src/examples/ode/simpleoscillator_prec.py
+++ b/docs/src/examples/ode/simpleoscillator_prec.py
@@ -1,4 +1,4 @@
-# Authors: B. Malengier, C. Abert
+# Authors: B. Malengier, C. Abert, F. Bruckner
 """
 This example shows how a preconditioned iterative linear solver
 is used to solve the Newton iterations arising from the solution
@@ -7,6 +7,8 @@ of the free vibration of a simple oscillator::
 using the CVODE solver. The rhs function is given by \dot{u}. The
 preconditioning is implemented in prec_solvefn which solves the
 system P = I - gamma * J, where J is the Jacobian of the rhs.
+The jac_times_vecfn calculates the Jacobian times vector product 
+using the analytic Jacobian. 
 Solution::
         u(t) = u_0*cos(sqrt(k/m)*t)+\dot{u}_0*sin(sqrt(k/m)*t)/sqrt(k/m)
     
@@ -28,6 +30,7 @@ def prec_solvefn(t, y, r, z, gamma, delta, lr):
     z[1] = - gamma*k/m * r[0] +         r[1]
 
 def jac_times_vecfn(v, Jv, t, y, user_data):
+    """ Calculate Jacobian times vector product Jv = J*v"""
     Jv[0] = v[1]
     Jv[1] = -k/m * v[0] 
 

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -39,7 +39,6 @@ cdef class CV_PrecSetupFunction:
                        object jcurPtr,
                        DTYPE_t gamma,
                        object userdata = *)
-
 cdef class CV_WrapPrecSetupFunction(CV_PrecSetupFunction):
     cpdef object _prec_setupfn
     cdef int with_userdata
@@ -54,11 +53,24 @@ cdef class CV_PrecSolveFunction:
                        DTYPE_t delta,
                        int lr,
                        object userdata = *)
-
 cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
     cpdef object _prec_solvefn
     cdef int with_userdata
     cpdef set_prec_solvefn(self, object prec_solvefn)
+
+
+cdef class CV_JacTimesVecFunction:
+    cpdef int evaluate(self,
+                       np.ndarray[DTYPE_t, ndim=1] v,
+                       np.ndarray[DTYPE_t, ndim=1] Jv,
+                       DTYPE_t t,
+                       np.ndarray[DTYPE_t, ndim=1] y,
+                       object userdata = *)
+cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
+    cpdef object _jac_times_vecfn
+    cdef int with_userdata
+    cpdef set_jac_times_vecfn(self, object jac_times_vecfn)
+
 
 cdef class CV_data:
     cdef np.ndarray yy_tmp, yp_tmp, jac_tmp, g_tmp, r_tmp, z_tmp
@@ -67,6 +79,7 @@ cdef class CV_data:
     cdef CV_RootFunction rootfn
     cdef CV_PrecSolveFunction prec_solvefn
     cdef CV_PrecSetupFunction prec_setupfn
+    cdef CV_JacTimesVecFunction jac_times_vecfn
     cdef bint parallel_implementation
     cdef object user_data
 

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -358,12 +358,23 @@ cdef class CV_JacTimesVecFunction:
                        DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        object userdata = None):
+        """
+        This function calculates the product of the Jacobian with a given vector v.
+        Use the userdata object to expose Jacobian related data to the solve function.
+
+        This is a generic class, you should subclass it for the problem specific
+        purposes.
+        """
         return 0
 
 cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
     cpdef set_jac_times_vecfn(self, object jac_times_vecfn):
         """
         Set some CV_JacTimesVecFn executable class.
+        """
+        """
+        set a jacobian-times-vector method as a CV_JacTimesVecFunction
+        executable class
         """
         self.with_userdata = 0
         nrarg = len(inspect.getargspec(jac_times_vecfn)[0])
@@ -1034,6 +1045,11 @@ cdef class CVODE:
 
                 if self.aux_data.jac_times_vecfn:
                     flag = CVSpilsSetJacTimesVecFn(cv_mem, _jac_times_vecfn)
+                if flag == CVSPILS_MEM_NULL:
+                    raise ValueError('LinSolver: The cvode mem pointer is NULL.')
+                elif flag == CVSPILS_LMEM_NULL:
+                    raise ValueError('LinSolver: The cvspils linear solver has '
+                                     'not been initialized.')
 
             else:
                 raise ValueError('LinSolver: Unknown solver type: %s'

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -330,6 +330,78 @@ cdef int _prec_solvefn(realtype tt, N_Vector yy, N_Vector ff, N_Vector r, N_Vect
 
     return 0
 
+# JacTimesVec function
+cdef class CV_JacTimesVecFunction:
+    cpdef int evaluate(self,
+                       np.ndarray[DTYPE_t, ndim=1] v,
+                       np.ndarray[DTYPE_t, ndim=1] Jv,
+                       DTYPE_t t,
+                       np.ndarray[DTYPE_t, ndim=1] y,
+                       object userdata = None):
+        return 0
+
+cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
+    cpdef set_jac_times_vecfn(self, object jac_times_vecfn):
+        """
+        Set some CV_JacTimesVecFn executable class.
+        """
+        self.with_userdata = 0
+        nrarg = len(inspect.getargspec(jac_times_vecfn)[0])
+        if nrarg > 5:
+            #hopefully a class method, self gives 6 arg!
+            self.with_userdata = 1
+        elif nrarg == 5 and inspect.isfunction(jac_times_vecfn):
+            self.with_userdata = 1
+        self._jac_times_vecfn = jac_times_vecfn
+
+    cpdef int evaluate(self,
+                       np.ndarray[DTYPE_t, ndim=1] v,
+                       np.ndarray[DTYPE_t, ndim=1] Jv,
+                       DTYPE_t t,
+                       np.ndarray[DTYPE_t, ndim=1] y,
+                       object userdata = None):
+        if self.with_userdata == 1:
+            self._jac_times_vecfn(v, Jv, t, y, userdata)
+        else:
+            self._jac_times_vecfn(v, Jv, t, y)
+        return 0
+
+cdef int _jac_times_vecfn(N_Vector v, N_Vector Jv, realtype t, N_Vector y, N_Vector fy,
+		void *user_data, N_Vector tmp):
+    """ function with the signature of CVSpilsJacTimesVecFn, that calls python function """
+    cdef np.ndarray[DTYPE_t, ndim=1] y_tmp, v_tmp, Jv_tmp
+
+    aux_data = <CV_data> user_data
+    cdef bint parallel_implementation = aux_data.parallel_implementation
+
+    if parallel_implementation:
+        raise NotImplemented
+    else:
+        y_tmp = aux_data.yy_tmp
+
+        if aux_data.r_tmp == None:
+            N = np.alen(y_tmp)
+            aux_data.r_tmp = np.empty(N, float)
+
+        if aux_data.z_tmp == None:
+            N = np.alen(y_tmp)
+            aux_data.z_tmp = np.empty(N, float)
+
+        v_tmp = aux_data.r_tmp
+        Jv_tmp = aux_data.z_tmp
+
+        nv_s2ndarray(y, y_tmp)
+        nv_s2ndarray(v, v_tmp)
+
+    aux_data.jac_times_vecfn.evaluate(v_tmp, Jv_tmp, t, y_tmp, aux_data.user_data)
+
+    if parallel_implementation:
+        raise NotImplemented
+    else:
+        ndarray2nv_s(Jv, Jv_tmp)
+
+    return 0
+
 
 cdef class CV_data:
     def __cinit__(self, N):
@@ -381,7 +453,8 @@ cdef class CVODE:
             'nr_rootfns': 0,
             'jacfn': None,
             'prec_setupfn': None,
-            'prec_solvefn': None
+            'prec_solvefn': None,
+            'jac_times_vecfn': None
             }
 
         self.verbosity = 1
@@ -551,6 +624,14 @@ cdef class CVODE:
                     parameters gamma and delta, input flag lr that determines
                     the flavour of the preconditioner (left = 1, right = 2) and
                     optional userdata.
+            'jac_times_vecfn':
+                Values: function of class CV_JacTimesVecFunction
+                Description:
+                    Defines a function that solves the product of vector v
+                    with an (approximate) Jacobian of the system J.
+                    This function takes as input arguments the vector v,
+                    result vector Jv, current time t, current value of y,
+                    and optional userdata.
             'bdf_stability_detection':
                 default = False, only used if lmm_type == 'bdf
             'max_conv_fails':
@@ -805,6 +886,14 @@ cdef class CVODE:
             opts['prec_solvefn'] = tmpfun
         self.aux_data.prec_solvefn = prec_solvefn
 
+        jac_times_vecfn = opts['jac_times_vecfn']
+        if jac_times_vecfn is not None and not isinstance(jac_times_vecfn, CV_JacTimesVecFunction):
+            tmpfun = CV_WrapJacTimesVecFunction()
+            tmpfun.set_jac_times_vecfn(jac_times_vecfn)
+            jac_times_vecfn = tmpfun
+            opts['jac_times_vecfn'] = tmpfun
+        self.aux_data.jac_times_vecfn = jac_times_vecfn
+
         self.aux_data.user_data = opts['user_data']
 
         self._set_runtime_changeable_options(opts, supress_supported_check=True)
@@ -919,6 +1008,9 @@ cdef class CVODE:
                     else:
                         flag = CVSpilsSetPreconditioner(cv_mem, NULL, _prec_solvefn)
                     #TODO check flag
+
+                if self.aux_data.jac_times_vecfn:
+                    flag = CVSpilsSetJacTimesVecFn(cv_mem, _jac_times_vecfn)
 
             else:
                 raise ValueError('LinSolver: Unknown solver type: %s'


### PR DESCRIPTION
Added support for providing CVSpilsJacTimesVecFn when one of the Krylov iterative linear solvers spgmr, spbcg, or sptfqmr is selected. This function allows to provide a user defined function instead of using the internal default method, which is based on a difference quotient approximation. 

Added analytical jacobian to 'simpleoscillator_prec.py' example. 