### PR TITLE
Added wrapper around CVodeSetErrHandlerFn

### DIFF
--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -71,6 +71,19 @@ cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
     cdef int with_userdata
     cpdef set_jac_times_vecfn(self, object jac_times_vecfn)
 
+cdef class CV_ErrHandler:
+    cpdef evaluate(self,
+                   int error_code,
+                   bytes module,
+                   bytes function,
+                   bytes msg,
+                   object user_data = *)
+
+cdef class CV_WrapErrHandler(CV_ErrHandler):
+    cpdef object _err_handler
+    cdef int with_userdata
+    cpdef set_err_handler(self, object err_handler)
+
 
 cdef class CV_data:
     cdef np.ndarray yy_tmp, yp_tmp, jac_tmp, g_tmp, r_tmp, z_tmp
@@ -82,6 +95,8 @@ cdef class CV_data:
     cdef CV_JacTimesVecFunction jac_times_vecfn
     cdef bint parallel_implementation
     cdef object user_data
+    cdef CV_ErrHandler err_handler
+    cdef object err_user_data
 
 cdef class CVODE:
     cdef N_Vector atol


### PR DESCRIPTION
Same as previous version, except rather than creating a new ErrData class, just add the error related stuff to the existing Data class.