### PR TITLE
Add CVODE api with both end points and roots

### DIFF
--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -93,7 +93,7 @@ cdef class CVODE:
     cdef N_Vector atol
     cdef void* _cv_mem
     cdef dict options
-    cdef bint parallel_implementation, initialized
+    cdef bint parallel_implementation, initialized, _old_api
     cdef CV_data aux_data
 
     cdef long int N #problem size, i.e. len(y0) = N


### PR DESCRIPTION
This is a updated version of https://github.com/aragilar/odes/tree/new-api which builds on top of interruptfn. If interruptfn is used, then the new api is used (I also created a new version of validate-flags at https://github.com/aragilar/odes/tree/validate-flags-v4 which uses the new api), otherwise the old api is used. It also makes the change of using a list for accumulating roots (which are converted to ndarrays at the end), avoiding the need for extending numpy arrays (I've timed this via ipython, and found that using lists were 10 times faster, which I'm not sure I trust, but it isn't slower...).