### PR TITLE
Separate tstop and root from errors via namedtuple

### DIFF
--- a/common.py
+++ b/common.py
@@ -17,6 +17,8 @@ LICENSE             = 'new BSD'
 
 DOWNLOAD_URL        = URL
 
+INSTALL_REQUIRES = ['scipy']
+
 MAJOR = 2
 MINOR = 1
 MICRO = 0
@@ -47,4 +49,3 @@ def write_version(fname):
     f.close()
 
 VERSION = build_fverstring()
-INSTALL_REQUIRE = 'scipy'

--- a/docs/src/examples/ode/simpleoscillator_new_api.py
+++ b/docs/src/examples/ode/simpleoscillator_new_api.py
@@ -1,0 +1,44 @@
+# Authors: B. Malengier
+"""
+This example shows the most simple way of using a solver.
+We solve free vibration of a simple oscillator::
+        m \ddot{u} + k u = 0, u(0) = u_0, \dot{u}(0) = \dot{u}_0
+using the CVODE solver, which means we use a rhs function of \dot{u}.
+Solution::
+        u(t) = u_0*cos(sqrt(k/m)*t)+\dot{u}_0*sin(sqrt(k/m)*t)/sqrt(k/m)
+
+"""
+from __future__ import print_function
+from numpy import asarray, cos, sin, sqrt
+
+#data
+k = 4.0
+m = 1.0
+#initial data on t=0, x[0] = u, x[1] = \dot{u}, xp = \dot{x}
+initx = [1, 0.1]
+
+#define function for the right-hand-side equations which has specific signature
+def rhseqn(t, x, xdot):
+    """ we create rhs equations for the problem"""
+    xdot[0] = x[1]
+    xdot[1] = - k/m * x[0]
+
+#instantiate the solver
+from scikits.odes import ode
+solver = ode('cvode', rhseqn, old_api=False) # force new api
+#obtain solution at a required time
+result = solver.solve([0., 1., 2.], initx).values
+
+print('\n   t        Solution          Exact')
+print('------------------------------------')
+for t, u in zip(result.t, result.y):
+    print('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))
+
+#continue the solver
+result = solver.solve([result.t[-1], result.t[-1]+1], result.y[-1]).values
+print('------------------------------------')
+print('  ...continuation of the solution')
+print('------------------------------------')
+
+for t, u in zip(result.t, result.y):
+    print ('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))

--- a/docs/src/examples/ode/simpleoscillator_new_roots.py
+++ b/docs/src/examples/ode/simpleoscillator_new_roots.py
@@ -1,0 +1,55 @@
+# Authors: B. Malengier
+"""
+This example shows the most simple way of using a solver.
+We solve free vibration of a simple oscillator::
+        m \ddot{u} + k u = 0, u(0) = u_0, \dot{u}(0) = \dot{u}_0
+using the CVODE solver, which means we use a rhs function of \dot{u}.
+Solution::
+        u(t) = u_0*cos(sqrt(k/m)*t)+\dot{u}_0*sin(sqrt(k/m)*t)/sqrt(k/m)
+
+"""
+from __future__ import print_function
+from numpy import asarray, cos, sin, sqrt, pi
+
+#data
+k = 4.0
+m = 1.0
+#initial data on t=0, x[0] = u, x[1] = \dot{u}, xp = \dot{x}
+initx = [1, 0.1]
+
+#define function for the right-hand-side equations which has specific signature
+def rhseqn(t, x, xdot):
+    """ we create rhs equations for the problem"""
+    xdot[0] = x[1]
+    xdot[1] = - k/m * x[0]
+
+def rootfn(t, x, g, userdata):
+    g[0] = 0 if abs(t - pi/2) < 1e-3 else 1
+def norootfn(t, x, g, userdata):
+    g[0] = 1
+#instantiate the solver
+from scikits.odes import ode
+solver = ode('cvode', rhseqn, rootfn=rootfn, nr_rootfns=1, old_api=False) # force new api
+#obtain solution at a required time
+soln = solver.solve([0., 1., 2.], initx)
+result = soln.values
+
+print('\n   t        Solution          Exact')
+print('------------------------------------')
+for t, u in zip(result.t, result.y):
+    print('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))
+
+
+print('------------------------------------')
+print('Root found at {:.6g}'.format(soln.roots.t[0]))
+
+solver.set_options(rootfn=norootfn, nr_rootfns=1)
+
+#continue the solver
+result = solver.solve([soln.roots.t[0], soln.roots.t[0] + 1], soln.roots.y[0]).values
+print('------------------------------------')
+print('  ...continuation of the solution')
+print('------------------------------------')
+
+for t, u in zip(result.t, result.y):
+    print ('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))

--- a/docs/src/examples/ode/simpleoscillator_new_tstop.py
+++ b/docs/src/examples/ode/simpleoscillator_new_tstop.py
@@ -1,0 +1,50 @@
+# Authors: B. Malengier
+"""
+This example shows the most simple way of using a solver.
+We solve free vibration of a simple oscillator::
+        m \ddot{u} + k u = 0, u(0) = u_0, \dot{u}(0) = \dot{u}_0
+using the CVODE solver, which means we use a rhs function of \dot{u}.
+Solution::
+        u(t) = u_0*cos(sqrt(k/m)*t)+\dot{u}_0*sin(sqrt(k/m)*t)/sqrt(k/m)
+
+"""
+from __future__ import print_function
+from numpy import asarray, cos, sin, sqrt
+
+#data
+k = 4.0
+m = 1.0
+#initial data on t=0, x[0] = u, x[1] = \dot{u}, xp = \dot{x}
+initx = [1, 0.1]
+
+#define function for the right-hand-side equations which has specific signature
+def rhseqn(t, x, xdot):
+    """ we create rhs equations for the problem"""
+    xdot[0] = x[1]
+    xdot[1] = - k/m * x[0]
+
+#instantiate the solver
+from scikits.odes import ode
+solver = ode('cvode', rhseqn, tstop=1.5, old_api=False) # force new api
+#obtain solution at a required time
+soln = solver.solve([0., 1., 2.], initx)
+result = soln.values
+tstop = soln.tstop
+
+print('\n   t        Solution          Exact')
+print('------------------------------------')
+for t, u in zip(result.t, result.y):
+    print('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))
+
+print('------------------------------------')
+print('Solution stopped at {0} with {1[0]:.4g}'.format(tstop.t[0], tstop.y[0]))
+
+solver.set_options(tstop=5)
+#continue the solver
+result = solver.solve([tstop.t[0], tstop.t[0]+1], tstop.y[0]).values
+print('------------------------------------')
+print('  ...continuation of the solution')
+print('------------------------------------')
+
+for t, u in zip(result[0], result[1]):
+    print ('%4.2f %15.6g %15.6g' % (t, u[0], initx[0]*cos(sqrt(k/m)*t)+initx[1]*sin(sqrt(k/m)*t)/sqrt(k/m)))

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -87,7 +87,7 @@ cdef class CVODE:
     cdef N_Vector atol
     cdef void* _cv_mem
     cdef dict options
-    cdef bint parallel_implementation, initialized
+    cdef bint parallel_implementation, initialized, _old_api
     cdef CV_data aux_data
 
     cdef long int N #problem size, i.e. len(y0) = N

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1290,10 +1290,7 @@ cdef class CVODE:
                     t = tspan[idx]
                     continue
                 else:
-                    return (
-                        flag, t_retn, y_retn, None, None, t_roots, y_roots,
-                        None, None, None
-                    )
+                    break
 
             elif flag == CV_ROOT_RETURN:
                 t_roots.append(np.copy(t_out))
@@ -1312,18 +1309,14 @@ cdef class CVODE:
         # return values computed so far
         t_retn  = t_retn[0:idx]
         y_retn  = y_retn[0:idx, :]
-        if flag == CV_ROOT_RETURN:
-            return (
-                flag, t_retn, y_retn, None, None, t_roots, y_roots,
-                t_tstop, y_tstop,
-            )
-        elif flag == CV_TSTOP_RETURN:
-            return (
-                flag, t_retn, y_retn, None, None, t_roots, y_roots,
-                t_tstop, y_tstop,
-            )
+        if flag < 0:
+            y_err = y_last
+            t_err = t_out
+        else:
+            y_err = None
+            t_err = None
         return (
-            flag, t_retn, y_retn, t_out, y_last, t_roots, y_roots,
+            flag, t_retn, y_retn, t_err, y_err, t_roots, y_roots,
             t_tstop, y_tstop,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ import setuptools
 
 from common import *
 
+if (sys.version_info[0] < 3) or (
+    sys.version_info[0] == 3 and sys.version_info[1] < 4
+):
+    INSTALL_REQUIRES.append('enum34')
+
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration(None, parent_package, top_path,
@@ -36,7 +41,7 @@ def setup_package():
         url = URL,
         license = LICENSE,
         configuration = configuration,
-        install_requires = 'scipy',
+        install_requires = INSTALL_REQUIRES,
         zip_safe = False
         )
     return


### PR DESCRIPTION
This is the successor to #18. The notable differences are that it uses IntEnum for the flag (making it easier to refer to in error messages etc., and a slight restructuring of the namedtuple. There are some examples included, based on those for the old api.

This should allow for easy addition of new features, such as the interruptfn/onroot and ontstop and the validate_flags features.