### PR TITLE
Add support for validating the status flag via exceptions

### DIFF
--- a/scikits/odes/sundials/__init__.py
+++ b/scikits/odes/sundials/__init__.py
@@ -2,4 +2,23 @@
 # odes - Extra ode integrators
 #
 
-#from .ida import *
+class CVODESolveException(Exception):
+    """Base class for exceptions raised by `CVODE.validate_flags`."""
+    def __init__(self, soln):
+        self.soln = soln
+        self.args = (self._message.format(soln),)
+
+class CVODESolveFailed(CVODESolveException):
+    """`CVODE.solve` failed to reach endpoint"""
+    _message = (
+        "Solver failed with flag {0.flag} and finished at {0.errors.t}"
+        "with values {0.errors.y}."
+    )
+
+class CVODESolveFoundRoot(CVODESolveException):
+    """`CVODE.solve` found a root"""
+    _message = "Solver found a root at {0.roots.t.[0]}."
+
+class CVODESolveReachedTSTOP(CVODESolveException):
+    """`CVODE.solve` reached the endpoint specified by tstop."""
+    _message = "Solver reached tstop at {0.tstop.t[0]}."

--- a/scikits/odes/sundials/__init__.py
+++ b/scikits/odes/sundials/__init__.py
@@ -17,7 +17,7 @@ class CVODESolveFailed(CVODESolveException):
 
 class CVODESolveFoundRoot(CVODESolveException):
     """`CVODE.solve` found a root"""
-    _message = "Solver found a root at {0.roots.t.[0]}."
+    _message = "Solver found a root at {0.roots.t[0]}."
 
 class CVODESolveReachedTSTOP(CVODESolveException):
     """`CVODE.solve` reached the endpoint specified by tstop."""

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -102,7 +102,7 @@ cdef class CVODE:
     cdef N_Vector atol
     cdef void* _cv_mem
     cdef dict options
-    cdef bint parallel_implementation, initialized, _old_api, _step_compute
+    cdef bint parallel_implementation, initialized, _old_api, _step_compute, _validate_flags
     cdef CV_data aux_data
 
     cdef long int N #problem size, i.e. len(y0) = N

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1603,11 +1603,15 @@ cdef class CVODE:
         """
         Validates the flag returned by `CVODE.solve`.
 
-        Validation happens using the following scheme: failures (flag < 0) raise
-        `CVODESolveFailed` or a subclass of it; finding a root raises
-        `CVODESolveFoundRoot`; reaching tstop raises `CVODESolveReachedTSTOP`;
-        and success without finding a root or reaching tstop returns the vectors
-        t_vals and y_vals.
+        Validation happens using the following scheme:
+         * failures (`flag` < 0) raise `CVODESolveFailed` or a subclass of it;
+         * finding a root (and stopping) raises `CVODESolveFoundRoot`;
+         * reaching `tstop` (and stopping) raises `CVODESolveReachedTSTOP`;
+         * otherwise, return an instance of `SolverReturn`.
+
+        In the case where ontstop or onroot are used, `CVODESolveFoundRoot` or
+        `CVODESolveReachedTSTOP` will be raised only if the solver is told to
+        stop at that point.
         """
         if soln.flag == StatusEnum.SUCCESS:
             return soln

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -7,6 +7,8 @@ from warnings import warn
 import numpy as np
 cimport numpy as np
 
+from . import CVODESolveFailed, CVODESolveFoundRoot, CVODESolveReachedTSTOP
+
 from .c_sundials cimport realtype, N_Vector
 from .c_cvode cimport *
 from .common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
@@ -79,6 +81,7 @@ STATUS_MESSAGE = {
     StatusEnum.TOO_CLOSE: "The output and initial times are too close to each other.",
 }
 
+WARNING_STR = "Solver succeeded with flag {} and finished at {} with values {}"
 
 # Right-hand side function
 cdef class CV_RhsFunction:
@@ -606,6 +609,7 @@ cdef class CVODE:
             'err_handler': None,
             'err_user_data': None,
             'old_api': None,
+            'validate_flags': None,
             }
 
         self.verbosity = 1
@@ -613,6 +617,7 @@ cdef class CVODE:
         self.N       = -1
         self._old_api = True # use old api by default
         self._step_compute = False #avoid dict lookup
+        self._validate_flags = False # don't validate by default
         self.set_options(rfn=Rfn, **options)
         self._cv_mem = NULL
         self.initialized = False
@@ -822,6 +827,12 @@ cdef class CVODE:
                     overloaded) if True or new api (namedtuple) if False.
                     Other options may require new api, hence using this should
                     be avoided if possible.
+            'validate_flags':
+                Values: True, False (=default)
+                Description:
+                    Controls whether to validate flags as a result of calling
+                    `solve`. See the `validate_flags` function for how this
+                    affects `solve`.
         """
 
         # Update values of all supplied options
@@ -974,6 +985,16 @@ cdef class CVODE:
                 raise ValueError("Option 'one_step_compute' requires 'old_api' to be False")
             self.options['one_step_compute'] = options['one_step_compute']
             self._step_compute = self.options['one_step_compute']
+
+        # Set validate status
+        if options.get('validate_flags') is not None:
+            validate_flags = options["validate_flags"]
+            if not validate_flags in [True, False]:
+                raise ValueError("Option 'validate_flags' must be True or False")
+            if validate_flags and self._old_api:
+                raise ValueError("Option 'validate_flags' requires 'old_api' to be False")
+            self.options['validate_flags'] = validate_flags
+            self._validate_flags = options["validate_flags"]
 
     def init_step(self, double t0, object y0):
         """
@@ -1400,7 +1421,7 @@ cdef class CVODE:
                 return flag, t, y, t_tstop[0], y_tstop[0]
             return flag, t, y, t_err, y_err
 
-        return SolverReturn(
+        soln = SolverReturn(
             flag=flag,
             values=SolverVariables(t=t, y=y),
             errors=SolverVariables(t=t_err, y=y_err),
@@ -1408,6 +1429,9 @@ cdef class CVODE:
             tstop=SolverVariables(t=t_tstop, y=y_tstop),
             message=STATUS_MESSAGE[flag]
         )
+        if self._validate_flags:
+            return self.validate_flags(soln)
+        return soln
 
     cpdef _solve(self, np.ndarray[DTYPE_t, ndim=1] tspan,
                  np.ndarray[DTYPE_t, ndim=1] y0):
@@ -1574,3 +1598,24 @@ cdef class CVODE:
         if not self.y0   is NULL: N_VDestroy(self.y0)
         if not self.y    is NULL: N_VDestroy(self.y)
         if not self.atol is NULL: N_VDestroy(self.atol)
+
+    def validate_flags(self, soln):
+        """
+        Validates the flag returned by `CVODE.solve`.
+
+        Validation happens using the following scheme: failures (flag < 0) raise
+        `CVODESolveFailed` or a subclass of it; finding a root raises
+        `CVODESolveFoundRoot`; reaching tstop raises `CVODESolveReachedTSTOP`;
+        and success without finding a root or reaching tstop returns the vectors
+        t_vals and y_vals.
+        """
+        if soln.flag == StatusEnum.SUCCESS:
+            return soln
+        if soln.flag < 0:
+            raise CVODESolveFailed(soln)
+        elif soln.flag == StatusEnum.TSTOP_RETURN:
+            raise CVODESolveReachedTSTOP(soln)
+        elif soln.flag == StatusEnum.ROOT_RETURN:
+            raise CVODESolveFoundRoot(soln)
+        warn(WARNING_STR.format(soln.flag, *soln.err_values))
+        return soln


### PR DESCRIPTION
Successor to #14, adds the option to make convert solver errors to exceptions, and raises exceptions on finding roots or reaching tstop.