### PR TITLE
Use pkg-config where available

### DIFF
--- a/scikits/odes/sundials/setup.py
+++ b/scikits/odes/sundials/setup.py
@@ -26,6 +26,24 @@ LIBS_CVODE    = ['sundials_cvode']
 LIB_DIRS_FORTRAN = []
 LIBS_FORTRAN     = []
 
+# use pkgconfig to find sundials
+PKGCONFIG_CVODE = 'sundials-cvode-serial'
+
+try:
+    import pkgconfig
+    try:
+        if pkgconfig.exists(PKGCONFIG_CVODE):
+            pkgconf = pkgconfig.parse(PKGCONFIG_CVODE)
+            for d in pkgconf['library_dirs']:
+                LIB_DIRS_SUNDIALS.append(str(d))
+            for d in pkgconf['include_dirs']:
+                INCL_DIRS_SUNDIALS.append(str(d))
+    except EnvironmentError:
+        pass
+except ImportError:
+    print("pkgconfig module not found, using preset paths")
+
+
 use_lapack = False
 try:
     if INCL_DIRS_LAPACK and LIB_DIRS_LAPACK and LIBS_LAPACK:


### PR DESCRIPTION
This adds some basic support for using pkgconfig where available. I've been working on patching sundials use of cmake to work better on Debian, and one of the things I've done is get it to make .pc files. 