### PR TITLE
Feature exception handling

### DIFF
--- a/scikits/odes/sundials/c_cvode.pxd
+++ b/scikits/odes/sundials/c_cvode.pxd
@@ -44,8 +44,8 @@ cdef extern from "cvode/cvode.h":
     enum: CV_BAD_DKY           #   -26
     enum: CV_TOO_CLOSE         #   -27
 
-    ctypedef int (*CVRhsFn)(realtype t, N_Vector y, N_Vector ydot, void *user_data) except? -1
-    ctypedef int (*CVRootFn)(realtype t, N_Vector y, realtype *gout, void *user_data)
+    ctypedef int (*CVRhsFn)(realtype t, N_Vector y, N_Vector ydot, void *user_data) except -1
+    ctypedef int (*CVRootFn)(realtype t, N_Vector y, realtype *gout, void *user_data) except -1
     ctypedef int (*CVEwtFn)(N_Vector y, N_Vector ewt, void *user_data)
     ctypedef void (*CVErrHandlerFn)(int error_code,
                                char *module, char *function,
@@ -131,7 +131,7 @@ cdef extern from "cvode/cvode_direct.h":
     ctypedef int (*CVDlsDenseJacFn)(long int N, realtype t,
                                     N_Vector y, N_Vector fy,
                                     DlsMat Jac, void *user_data,
-                                    N_Vector tmp1, N_Vector tmp2, N_Vector tmp3)
+                                    N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except -1
     ctypedef int (*CVDlsBandJacFn)(long int N, long int mupper, long int mlower,
                                    realtype t, N_Vector y, N_Vector fy,
                                    DlsMat Jac, void *user_data,
@@ -212,14 +212,14 @@ cdef extern from "cvode/cvode_spils.h":
                                   booleantype jok, booleantype *jcurPtr,
                                   realtype gamma, void *user_data,
                                   N_Vector tmp1, N_Vector tmp2,
-                                  N_Vector tmp3)
+                                  N_Vector tmp3) except -1
     ctypedef int (*CVSpilsPrecSolveFn)(realtype t, N_Vector y, N_Vector fy,
                                   N_Vector r, N_Vector z,
                                   realtype gamma, realtype delta,
-                                  int lr, void *user_data, N_Vector tmp)
+                                  int lr, void *user_data, N_Vector tmp) except -1
     ctypedef int (*CVSpilsJacTimesVecFn)(N_Vector v, N_Vector Jv, realtype t,
                                     N_Vector y, N_Vector fy,
-                                    void *user_data, N_Vector tmp)
+                                    void *user_data, N_Vector tmp) except -1
 
     int CVSpilsSetPrecType(void *cvode_mem, int pretype)
     int CVSpilsSetGSType(void *cvode_mem, int gstype)

--- a/scikits/odes/sundials/c_cvode.pxd
+++ b/scikits/odes/sundials/c_cvode.pxd
@@ -44,8 +44,7 @@ cdef extern from "cvode/cvode.h":
     enum: CV_BAD_DKY           #   -26
     enum: CV_TOO_CLOSE         #   -27
 
-    ctypedef int (*CVRhsFn)(realtype t, N_Vector y,
-                    N_Vector ydot, void *user_data)
+    ctypedef int (*CVRhsFn)(realtype t, N_Vector y, N_Vector ydot, void *user_data) except? -1
     ctypedef int (*CVRootFn)(realtype t, N_Vector y, realtype *gout, void *user_data)
     ctypedef int (*CVEwtFn)(N_Vector y, N_Vector ewt, void *user_data)
     ctypedef void (*CVErrHandlerFn)(int error_code,

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -7,7 +7,7 @@ cdef class CV_RhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
-                       object userdata = *) except? -1
+                       object userdata = *) except -1
 cdef class CV_WrapRhsFunction(CV_RhsFunction):
     cpdef public object _rhsfn
     cdef public int with_userdata
@@ -17,7 +17,7 @@ cdef class CV_RootFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] g,
-                       object userdata = *)
+                       object userdata = *) except -1
 cdef class CV_WrapRootFunction(CV_RootFunction):
     cpdef object _rootfn
     cdef int with_userdata
@@ -26,7 +26,7 @@ cdef class CV_WrapRootFunction(CV_RootFunction):
 cdef class CV_JacRhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       np.ndarray[DTYPE_t, ndim=2] J)
+                       np.ndarray[DTYPE_t, ndim=2] J) except -1
 cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
     cpdef public object _jacfn
     cdef int with_userdata
@@ -38,7 +38,7 @@ cdef class CV_PrecSetupFunction:
                        bint jok,
                        object jcurPtr,
                        DTYPE_t gamma,
-                       object userdata = *)
+                       object userdata = *) except -1
 cdef class CV_WrapPrecSetupFunction(CV_PrecSetupFunction):
     cpdef object _prec_setupfn
     cdef int with_userdata
@@ -52,7 +52,7 @@ cdef class CV_PrecSolveFunction:
                        DTYPE_t gamma,
                        DTYPE_t delta,
                        int lr,
-                       object userdata = *)
+                       object userdata = *) except -1
 cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
     cpdef object _prec_solvefn
     cdef int with_userdata
@@ -65,7 +65,7 @@ cdef class CV_JacTimesVecFunction:
                        np.ndarray[DTYPE_t, ndim=1] Jv,
                        DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       object userdata = *)
+                       object userdata = *) except -1
 cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
     cpdef object _jac_times_vecfn
     cdef int with_userdata

--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -7,7 +7,7 @@ cdef class CV_RhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
-                       object userdata = *)
+                       object userdata = *) except? -1
 cdef class CV_WrapRhsFunction(CV_RhsFunction):
     cpdef public object _rhsfn
     cdef public int with_userdata

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -109,7 +109,7 @@ cdef class CV_WrapRhsFunction(CV_RhsFunction):
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
-                       object userdata = None):
+                       object userdata = None) except? -1:
         if self.with_userdata == 1:
             self._rhsfn(t, y, ydot, userdata)
         else:
@@ -117,7 +117,7 @@ cdef class CV_WrapRhsFunction(CV_RhsFunction):
         return 0
 
 cdef int _rhsfn(realtype tt, N_Vector yy, N_Vector yp,
-              void *auxiliary_data):
+              void *auxiliary_data) except? -1:
     """ function with the signature of CVRhsFn, that calls python Rhs """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp
 

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -88,7 +88,7 @@ cdef class CV_RhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
-                       object userdata = None):
+                       object userdata = None) except -1:
         return 0
 
 cdef class CV_WrapRhsFunction(CV_RhsFunction):
@@ -109,7 +109,7 @@ cdef class CV_WrapRhsFunction(CV_RhsFunction):
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
-                       object userdata = None) except? -1:
+                       object userdata = None) except -1:
         if self.with_userdata == 1:
             self._rhsfn(t, y, ydot, userdata)
         else:
@@ -117,7 +117,7 @@ cdef class CV_WrapRhsFunction(CV_RhsFunction):
         return 0
 
 cdef int _rhsfn(realtype tt, N_Vector yy, N_Vector yp,
-              void *auxiliary_data) except? -1:
+              void *auxiliary_data) except -1:
     """ function with the signature of CVRhsFn, that calls python Rhs """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp
 
@@ -147,7 +147,7 @@ cdef class CV_RootFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] g,
-                       object userdata = None):
+                       object userdata = None) except -1:
         return 0
 
 cdef class CV_WrapRootFunction(CV_RootFunction):
@@ -167,14 +167,14 @@ cdef class CV_WrapRootFunction(CV_RootFunction):
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] g,
-                       object userdata = None):
+                       object userdata = None) except -1:
         if self.with_userdata == 1:
             self._rootfn(t, y, g, userdata)
         else:
             self._rootfn(t, y, g)
         return 0
 
-cdef int _rootfn(realtype t, N_Vector y, realtype *gout, void *auxiliary_data):
+cdef int _rootfn(realtype t, N_Vector y, realtype *gout, void *auxiliary_data) except -1:
     """ function with the signature of CVRootFn """
 
     aux_data = <CV_data> auxiliary_data
@@ -203,7 +203,7 @@ cdef int _rootfn(realtype t, N_Vector y, realtype *gout, void *auxiliary_data):
 cdef class CV_JacRhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       np.ndarray J):
+                       np.ndarray J) except -1:
         """
         Returns the Jacobi matrix of the right hand side function, as
             d(rhs)/d y
@@ -225,7 +225,7 @@ cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
 
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       np.ndarray J):
+                       np.ndarray J) except -1:
         """
         Returns the Jacobi matrix (for dense the full matrix, for band only
         bands. Result has to be stored in the variable J, which is preallocated
@@ -240,7 +240,7 @@ cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
 
 cdef int _jacdense(long int Neq, realtype tt,
             N_Vector yy, N_Vector ff, DlsMat Jac,
-            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3):
+            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except -1:
     """function with the signature of CVDlsDenseJacFn that calls python Jac"""
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp
     cdef np.ndarray jac_tmp
@@ -274,7 +274,7 @@ cdef class CV_PrecSetupFunction:
                        bint jok,
                        object jcurPtr,
                        DTYPE_t gamma,
-                       object userdata = None):
+                       object userdata = None) except -1:
         """
         This function preprocesses and/or evaluates Jacobian-related data
         needed by the preconditioner. Use the userdata object to expose
@@ -305,7 +305,7 @@ cdef class CV_WrapPrecSetupFunction(CV_PrecSetupFunction):
                        bint jok,
                        object jcurPtr,
                        DTYPE_t gamma,
-                       object userdata = None):
+                       object userdata = None) except -1:
         if self.with_userdata == 1:
             self._prec_setupfn(t, y, jok, jcurPtr, gamma, userdata)
         else:
@@ -317,7 +317,7 @@ class MutableBool(object):
         self.value = value
 
 cdef int _prec_setupfn(realtype tt, N_Vector yy, N_Vector ff, booleantype jok, booleantype *jcurPtr,
-         realtype gamma, void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3):
+         realtype gamma, void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except -1:
     """ function with the signature of CVSpilsPrecSetupFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp
 
@@ -344,7 +344,7 @@ cdef class CV_PrecSolveFunction:
                        DTYPE_t gamma,
                        DTYPE_t delta,
                        int lr,
-                       object userdata = None):
+                       object userdata = None) except -1:
         """
         This function solves the preconditioned system P*z = r, where P may be
         either a left or right preconditioner matrix. Here P should approximate
@@ -379,7 +379,7 @@ cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
                        DTYPE_t gamma,
                        DTYPE_t delta,
                        int lr,
-                       object userdata = None):
+                       object userdata = None) except -1:
         if self.with_userdata == 1:
             self._prec_solvefn(t, y, r, z, gamma, delta, lr, userdata)
         else:
@@ -387,7 +387,7 @@ cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
         return 0
 
 cdef int _prec_solvefn(realtype tt, N_Vector yy, N_Vector ff, N_Vector r, N_Vector z,
-         realtype gamma, realtype delta, int lr, void *auxiliary_data, N_Vector tmp):
+         realtype gamma, realtype delta, int lr, void *auxiliary_data, N_Vector tmp) except -1:
     """ function with the signature of CVSpilsPrecSolveFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, r_tmp, z_tmp
 
@@ -429,7 +429,7 @@ cdef class CV_JacTimesVecFunction:
                        np.ndarray[DTYPE_t, ndim=1] Jv,
                        DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       object userdata = None):
+                       object userdata = None) except -1:
         """
         This function calculates the product of the Jacobian with a given vector v.
         Use the userdata object to expose Jacobian related data to the solve function.
@@ -462,15 +462,15 @@ cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
                        np.ndarray[DTYPE_t, ndim=1] Jv,
                        DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
-                       object userdata = None):
+                       object userdata = None) except -1:
         if self.with_userdata == 1:
             self._jac_times_vecfn(v, Jv, t, y, userdata)
         else:
             self._jac_times_vecfn(v, Jv, t, y)
         return 0
 
-cdef int _jac_times_vecfn(N_Vector v, N_Vector Jv, realtype t, N_Vector y,
-                          N_Vector fy, void *user_data, N_Vector tmp):
+cdef int _jac_times_vecfn(N_Vector v, N_Vector Jv, realtype t, N_Vector y, 
+                          N_Vector fy, void *user_data, N_Vector tmp) except -1:
     """ function with the signature of CVSpilsJacTimesVecFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] y_tmp, v_tmp, Jv_tmp
 


### PR DESCRIPTION
Make Cython C-Function return -1 error code on internal exceptions. Otherwise internal execptions are ignored and not passed on to the calling python function. 

NOTE: code was tested for CV_WrapPrecSetupFunction.evaluate() and CV_WrapRhsFunction.evaluate(), but it should work also for the rest. 

greetings 
Florian
