### PR TITLE
allow setting SUNDIALS installation directory from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ In the top directory (the same as the file you are reading now), just do as root
 ```
  python setup.py build
 ```
-This builds the packages in the build directory. Libraries are searched in `/usr/lib` 
-and `/usr/local/lib`, edit `setup.py` in `odes/scikits/odes/sundials/` variable `LIB_DIRS_SUNDIALS` to search in another location.
+This builds the packages in the build directory.
+Libraries are searched in `/usr/lib` and `/usr/local/lib` by default.
+You can also set `$SUNDIALS_INST` in your environment to the directory you have installed SUNDIALS into.
+It should contain `lib` and `include` directories.
 
 For a working scikit compile, LAPACK, ATLAS and BLAS must be found. A typical output of the build is:
     lapack_info:

--- a/scikits/odes/sundials/setup.py
+++ b/scikits/odes/sundials/setup.py
@@ -43,6 +43,13 @@ try:
 except ImportError:
     print("pkgconfig module not found, using preset paths")
 
+if "SUNDIALS_INST" in os.environ:
+    LIB_DIRS_SUNDIALS.append(os.path.join(os.environ["SUNDIALS_INST"], "lib"))
+    INCL_DIRS_SUNDIALS.append(os.path.join(os.environ["SUNDIALS_INST"], "include"))
+    print("SUNDIALS installation path set to `{}` via $SUNDIALS_INST.".format(
+        os.environ["SUNDIALS_INST"]))
+else:
+    print("No path for SUNDIALS installation set by $SUNDIALS_INST.")
 
 use_lapack = False
 try:


### PR DESCRIPTION
This patch adds a way to specify the SUNDIALS installation directory via `$SUNDIALS_INST`.
I have tested this both locally and on travis, c.f. https://travis-ci.org/logicabrity/conda_odes .

In my opinion, this is better than to have to edit or patch the `odes/scikits/odes/sundials/setup.py` file by hand before installation.