### PR TITLE
add get_info method #28

### DIFF
--- a/scikits/odes/ode.py
+++ b/scikits/odes/ode.py
@@ -414,6 +414,21 @@ More examples in the Examples_ directory and IPython_ worksheets.
         else:
             self._integrator.set_options(tstop=tstop)
 
+    def get_info(self):
+        """
+        Return additional information about the state of the integrator.
+
+        Returns
+        -------
+
+        A dictionary filled with internal data as exposed by the chosen integrator.
+
+        """
+        if hasattr(self._integrator, 'get_info'):
+            return self._integrator.get_info()
+        else:
+            return {}
+
 #------------------------------------------------------------------------------
 # ODE integrators
 #------------------------------------------------------------------------------
@@ -450,4 +465,4 @@ def find_ode_integrator(name):
             return cl
         elif hasattr(cl, name) and re.match(name, cl.name, re.I):
             return cl
-    raise ValueError('Integrator name %s does not exsist' % name)
+    raise ValueError('Integrator name %s does not exist' % name)

--- a/scikits/odes/ode.py
+++ b/scikits/odes/ode.py
@@ -421,7 +421,8 @@ More examples in the Examples_ directory and IPython_ worksheets.
         Returns
         -------
 
-        A dictionary filled with internal data as exposed by the chosen integrator.
+        A dictionary filled with internal data as exposed by the integrator.
+        See the `get_info` method of your chosen integrator for details.
 
         """
         if hasattr(self._integrator, 'get_info'):

--- a/scikits/odes/tests/test_get_info.py
+++ b/scikits/odes/tests/test_get_info.py
@@ -1,0 +1,31 @@
+import numpy as np
+import unittest
+from scikits.odes import ode
+
+xs = np.linspace(1, 10, 10)
+
+
+def true_y(x):
+    """ just a dummy this test module is not about the integration itself """
+    return np.power(x, 2)
+    #return np.sin(x) / (x + 0.1)
+
+
+def rhs(x, y, ydot):
+    ydot[:] = 2 * x
+    #ydot[:] = (np.cos(x) * (x + 0.1) - np.sin(x)) / np.pow((x + 0.1), 2)
+
+
+class GetInfoTest(unittest.TestCase):
+    def setUp(self):
+        self.ode = ode('cvode', rhs, old_api=False)
+        self.solution = self.ode.solve(xs, np.array([1]))
+
+    def test_we_integrated_correctly(self):
+        true_ys = true_y(xs)
+        rel_diff = np.abs(self.solution.values.y - true_ys) / true_ys
+        print "Relative difference is d_max={}.".format(rel_diff.max())
+        assert rel_diff.max() < 1e-6
+
+    def test_get_info_is_exposed_on_ode(self):
+        ode.get_info()

--- a/scikits/odes/tests/test_get_info.py
+++ b/scikits/odes/tests/test_get_info.py
@@ -1,6 +1,8 @@
+from __future__ import print_function
 import numpy as np
 import unittest
 from scikits.odes import ode
+
 
 xs = np.linspace(1, 10, 10)
 
@@ -23,9 +25,33 @@ class GetInfoTest(unittest.TestCase):
 
     def test_we_integrated_correctly(self):
         true_ys = true_y(xs)
-        rel_diff = np.abs(self.solution.values.y - true_ys) / true_ys
-        print "Relative difference is d_max={}.".format(rel_diff.max())
+        diff = np.abs(self.solution.values.y[:, 0] - true_ys)
+        rel_diff = diff / true_ys
+        print("True solution:\n", true_ys)
+        print("Integrated:\n", self.solution.values.y[:, 0])
+        print("Difference:\n", diff)
+        print("Relative:\n", rel_diff)
         assert rel_diff.max() < 1e-6
 
     def test_get_info_is_exposed_on_ode(self):
-        ode.get_info()
+        self.ode.get_info()
+
+    def test_get_info_returns_dict(self):
+        assert isinstance(self.ode.get_info(), dict)
+
+    def test_ode_exposes_num_rhs_evals(self):
+        info = self.ode.get_info()
+        print("ode.get_info() =\n", info)
+        assert 'NumRhsEvals' in info
+        assert info['NumRhsEvals'] > 0
+
+class GetInfoTestSpils(unittest.TestCase):
+    def setUp(self):
+        self.ode = ode('cvode', rhs, linsolver="spgmr", old_api=False)
+        self.solution = self.ode.solve(xs, np.array([1]))
+
+    def test_ode_exposes_num_njtimes_evals(self):
+        info = self.ode.get_info()
+        print("ode.get_info() =\n", info)
+        assert 'NumJtimesEvals' in info
+        assert info['NumJtimesEvals'] > 0


### PR DESCRIPTION
Modelled after the outline given by bmcage in issue #28, this pull request adds methods to expose some internal solver state, like the number of evaluations of the right-hand side for instance.