### PR TITLE
Add support for travis ci and tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,4 @@ build*
 docs/src/examples/scikits
 dist
 _build
-
-
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+language: python
+
+notifications:
+  email: false
+
+addons:
+  apt:
+    packages:
+      # commented as ubuntu's sundials is too old
+      #- libsundials-serial-dev
+      - gfortran
+      - liblapack-dev
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/sundials
+
+env:
+  - TOXENV=py26
+    PIP_VERBOSE=1
+  - TOXENV=py27
+    PIP_VERBOSE=1
+  - TOXENV=py33
+    PIP_VERBOSE=1
+  - TOXENV=py34
+    PIP_VERBOSE=1
+#  - TOXENV=py35
+# commented out because of https://github.com/travis-ci/travis-ci/issues/4794
+
+matrix:
+  include:
+    # needed to work around https://github.com/travis-ci/travis-ci/issues/4794
+    - python: 3.5
+      env:
+      - TOXENV=py35
+        PIP_VERBOSE=1
+
+install:
+  - source ci_support/ensure_sundials_installed.sh
+  - pip install -U pip setuptools virtualenv wheel
+  - pip install -U tox
+
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,9 @@ cache:
     - $HOME/sundials
 
 env:
-  - TOXENV=py26
-    PIP_VERBOSE=1
   - TOXENV=py27
-    PIP_VERBOSE=1
   - TOXENV=py33
-    PIP_VERBOSE=1
   - TOXENV=py34
-    PIP_VERBOSE=1
 #  - TOXENV=py35
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
 
@@ -36,7 +31,6 @@ matrix:
     - python: 3.5
       env:
       - TOXENV=py35
-        PIP_VERBOSE=1
 
 install:
   - source ci_support/ensure_sundials_installed.sh

--- a/ci_support/ensure_sundials_installed.sh
+++ b/ci_support/ensure_sundials_installed.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+export SUNDIALS_DIR=$HOME/sundials
+SUNDIALS_LIBDIR=$SUNDIALS_DIR/lib
+SUNDIALS_INCLUDEDIR=$SUNDIALS_DIR/include
+
+if [ ! -d "$SUNDIALS_LIBDIR" ]; then
+    mkdir -p $SUNDIALS_DIR
+    echo "Installing sundials"
+    ./ci_support/install_sundials.sh
+else
+    echo "Using cached sundials"
+fi
+
+export LD_LIBRARY_PATH=$SUNDIALS_LIBDIR:$LD_LIBRARY_PATH
+export LIBRARY_PATH=$SUNDIALS_LIBDIR:$LIBRARY_PATH
+export CPATH=$SUNDIALS_INCLUDEDIR:$CPATH

--- a/ci_support/install_sundials.sh
+++ b/ci_support/install_sundials.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -ex
+
+wget http://computation.llnl.gov/projects/sundials-suite-nonlinear-differential-algebraic-equation-solvers/download/sundials-2.6.2.tar.gz
+
+tar -xzvf sundials-2.6.2.tar.gz
+
+mkdir sundials_build
+
+cd sundials_build &&
+    cmake -DCMAKE_INSTALL_PREFIX=$SUNDIALS_DIR -DLAPACK_ENABLE=ON ../sundials-2.6.2 &&
+    make && make install

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+envlist = py27,py32,py33,py34,py35
+skipsdist=True
+
+[testenv]
+whitelist_externals=env
+passenv=
+    SUNDIALS_DIR
+    LD_LIBRARY_PATH
+    LIBRARY_PATH
+    CPATH
+    PIP_VERBOSE
+deps =
+    numpy
+    cython
+    nose
+    pytest
+    wheel
+commands =
+    env
+    pip install {toxinidir}
+    py.test --pyargs scikits.odes {posargs}
+changedir =
+    {toxworkdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py32,py33,py34,py35
+envlist = py27,py33,py34,py35
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
This adds support for two testing utilities, [tox](https://testrun.org/tox/latest/) and [travis ci](https://travis-ci.org/).