### PR TITLE
Add support for readthedocs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
+[![Documentation Status](https://readthedocs.org/projects/scikits-odes/badge/?version=latest)](http://scikits-odes.readthedocs.org/en/latest/?badge=latest)
+[![Build Status](https://travis-ci.org/bmcage/scikits.odes.svg?branch=master)](https://travis-ci.org/bmcage/scikits.odes)
+[![Version](https://img.shields.io/pypi/v/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
+[![License](https://img.shields.io/pypi/l/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
+[![Supported versions](https://img.shields.io/pypi/pyversions/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
+[![Supported implementations](https://img.shields.io/pypi/implementation/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
+[![PyPI](https://img.shields.io/pypi/status/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
+
 This is a scikit offering some extra ode/dae solvers, so they can mature outside of scipy. The main solvers to use
 are the *Sundials* solvers.
 
 # General info
 
 * You need scipy, 
-* Tested with python 2.7 and 3.2
+* Tested with python 2.7 and 3.2-3.5
 * Available solvers:
     * BDF linear multistep method  for stiff problems. This is done or via *cvode*, which is an improvement on the ode (vode/dvode) solver in scipy.integrate, or for DAE systems via *ida*. Both are part of the sundials package. Use it to have modern features
     * Adams-Moulton linear multistep method for nonstiff problems. This is done also via *cvode* or *ida* (option lmm_type='ADAMS')
@@ -139,7 +147,7 @@ See the examples for more info.
 
 You need nose to run the tests. Eg, to install it, run
 ```
-easy_install nose
+pip install nose
 ```
 To run the tests do in the python shell:
 

--- a/common.py
+++ b/common.py
@@ -30,7 +30,15 @@ CLASSIFIERS = [
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
-        'Topic :: Scientific/Engineering']
+        'Topic :: Scientific/Engineering',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+]
 
 def build_verstring():
     return '%d.%d.%d' % (MAJOR, MINOR, MICRO)

--- a/sphinxdoc/conf.py
+++ b/sphinxdoc/conf.py
@@ -18,6 +18,16 @@ import os
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+from mock import Mock as MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return Mock()
+
+MOCK_MODULES = ['numpy', 'scikits.odes.ode.sundials']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
@@ -32,7 +42,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',
-    'numpydoc'
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/sphinxdoc/requirements.txt
+++ b/sphinxdoc/requirements.txt
@@ -1,0 +1,2 @@
+sphinx>=1.3
+mock


### PR DESCRIPTION
This allows the sphinx docs to be built by [read the docs](https://readthedocs.org/), which hosts docs for projects. I've set it up at https://scikits-odes.readthedocs.io/ (You can see what it looks like at https://scikits-odes.readthedocs.io/en/rtd_support/). Currently its building off my github repo as there needs to be a webhook allowed by your github account, so when that's set I'll move it over to this repo.