### PR TITLE
Use inspect.signature where available based on deprecation of inspect.getargspec

### DIFF
--- a/scikits/odes/sundials/__init__.py
+++ b/scikits/odes/sundials/__init__.py
@@ -2,6 +2,8 @@
 # odes - Extra ode integrators
 #
 
+import inspect
+
 class CVODESolveException(Exception):
     """Base class for exceptions raised by `CVODE.validate_flags`."""
     def __init__(self, soln):
@@ -43,3 +45,22 @@ class IDASolveFoundRoot(IDASolveException):
 class IDASolveReachedTSTOP(IDASolveException):
     """`IDA.solve` reached the endpoint specified by tstop."""
     _message = "Solver reached tstop at {0.tstop.t[0]}."
+
+
+def _get_num_args(func):
+    """
+    Python 2/3 compatible method of getting number of args that `func` accepts
+    """
+    if hasattr(inspect, "signature"):
+        sig = inspect.signature(func)
+        numargs = 0
+        for param in sig.parameters.values():
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            ):
+                numargs += 1
+        return numargs
+    else:
+        return len(inspect.getargspec(func).args)

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -7,7 +7,10 @@ from warnings import warn
 import numpy as np
 cimport numpy as np
 
-from . import CVODESolveFailed, CVODESolveFoundRoot, CVODESolveReachedTSTOP
+from . import (
+    CVODESolveFailed, CVODESolveFoundRoot, CVODESolveReachedTSTOP,
+    _get_num_args,
+)
 
 from .c_sundials cimport realtype, N_Vector
 from .c_cvode cimport *
@@ -105,7 +108,7 @@ cdef class CV_WrapRhsFunction(CV_RhsFunction):
         set some rhs equations as a RhsFunction executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(rhsfn)[0])
+        nrarg = _get_num_args(rhsfn)
         if nrarg > 4:
             #hopefully a class method, self gives 5 arg!
             self.with_userdata = 1
@@ -171,7 +174,7 @@ cdef class CV_WrapRootFunction(CV_RootFunction):
         set root-ing condition(equations) as a RootFunction executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(rootfn)[0])
+        nrarg = _get_num_args(rootfn)
         if nrarg > 4:
             #hopefully a class method, self gives 4 arg!
             self.with_userdata = 1
@@ -326,7 +329,7 @@ cdef class CV_WrapPrecSetupFunction(CV_PrecSetupFunction):
         executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(prec_setupfn)[0])
+        nrarg = _get_num_args(prec_setupfn)
         if nrarg > 6:
             #hopefully a class method, self gives 7 arg!
             self.with_userdata = 1
@@ -407,7 +410,7 @@ cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
         executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(prec_solvefn)[0])
+        nrarg = _get_num_args(prec_solvefn)
         if nrarg > 8:
             #hopefully a class method, self gives 9 arg!
             self.with_userdata = 1
@@ -501,7 +504,7 @@ cdef class CV_WrapJacTimesVecFunction(CV_JacTimesVecFunction):
         executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(jac_times_vecfn)[0])
+        nrarg = _get_num_args(jac_times_vecfn)
         if nrarg > 5:
             #hopefully a class method, self gives 6 arg!
             self.with_userdata = 1
@@ -589,7 +592,7 @@ cdef class CV_WrapErrHandler(CV_ErrHandler):
         """
         set some (c/p)ython function as the error handler
         """
-        nrarg = len(inspect.getargspec(err_handler)[0])
+        nrarg = _get_num_args(err_handler)
         self.with_userdata = (nrarg > 5) or (
             nrarg == 5 and inspect.isfunction(err_handler)
         )

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -10,7 +10,9 @@ cimport numpy as np
 from .c_sundials cimport realtype, N_Vector
 from .c_ida cimport *
 from .common_defs cimport (nv_s2ndarray, ndarray2nv_s, ndarray2DlsMatd)
-from . import IDASolveFailed, IDASolveFoundRoot, IDASolveReachedTSTOP
+from . import (
+    IDASolveFailed, IDASolveFoundRoot, IDASolveReachedTSTOP, _get_num_args,
+)
 
 # TODO: parallel implementation: N_VectorParallel
 # TODO: linsolvers: check the output value for errors
@@ -113,7 +115,7 @@ cdef class IDA_WrapRhsFunction(IDA_RhsFunction):
         set some residual equations as a ResFunction executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(resfn)[0])
+        nrarg = _get_num_args(resfn)
         if nrarg > 5:
             # hopefully a class method
             self.with_userdata = 1
@@ -183,7 +185,7 @@ cdef class IDA_WrapRootFunction(IDA_RootFunction):
         set root-ing condition(equations) as a RootFunction executable class
         """
         self.with_userdata = 0
-        nrarg = len(inspect.getargspec(rootfn)[0])
+        nrarg = _get_num_args(rootfn)
         if nrarg > 5:
             #hopefully a class method, self gives 5 arg!
             self.with_userdata = 1
@@ -346,7 +348,7 @@ cdef class IDA_WrapErrHandler(IDA_ErrHandler):
         """
         set some (c/p)ython function as the error handler
         """
-        nrarg = len(inspect.getargspec(err_handler)[0])
+        nrarg = _get_num_args(err_handler)
         self.with_userdata = (nrarg > 5) or (
             nrarg == 5 and inspect.isfunction(err_handler)
         )

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ passenv=
     CPATH
     PIP_VERBOSE
 deps =
-    numpy
+    py33: numpy<1.11
+    py{27,34,35}: numpy
     cython
     nose
     pytest


### PR DESCRIPTION
inspect.getargspec is deprecated on Python 3, this adds a wrapper around the inspect module which performs the correct invocation to get the required number of arguments.