### PR TITLE
Fix setup.py and README so that classifiers work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Documentation Status](https://readthedocs.org/projects/scikits-odes/badge/?version=latest)](http://scikits-odes.readthedocs.org/en/latest/?badge=latest)
-[![Build Status](https://travis-ci.org/bmcage/scikits.odes.svg?branch=master)](https://travis-ci.org/bmcage/scikits.odes)
+[![Build Status](https://travis-ci.org/bmcage/odes.svg?branch=master)](https://travis-ci.org/bmcage/odes)
 [![Version](https://img.shields.io/pypi/v/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
 [![License](https://img.shields.io/pypi/l/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)
 [![Supported versions](https://img.shields.io/pypi/pyversions/scikits.odes.svg)](https://pypi.python.org/pypi/scikits.odes/)

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ if (sys.version_info[0] < 3) or (
 def configuration(parent_package='',top_path=None):
     from numpy.distutils.misc_util import Configuration
     config = Configuration(None, parent_package, top_path,
-        license = LICENSE,
-        download_url = DOWNLOAD_URL,
-        long_description = LONG_DESCRIPTION,
         namespace_packages=['scikits'])
     # Avoid non-useful msg: "Ignoring attempt to set 'name' (from ... "
     config.set_options(
@@ -46,6 +43,7 @@ def setup_package():
         maintainer = MAINTAINER,
         maintainer_email = MAINTAINER_EMAIL,
         description = DESCRIPTION,
+        long_description = LONG_DESCRIPTION,
         url = URL,
         license = LICENSE,
         configuration = configuration,
@@ -55,6 +53,7 @@ def setup_package():
             # If any package contains *.pxd files, include them:
             '': ['*.pxd'],
         },
+        classifiers=CLASSIFIERS,
         )
     return
 


### PR DESCRIPTION
This fixes the setup.py so that classifiers are included, and fixes some fields which were duplicated. WIth the classifier fix, all the badges should be fixed also when a new upload to PyPI is made.