### PR TITLE
Add PEP 518 (i.e. pyproject.toml) support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include common.py scikits/odes/sundials/sundials_auxiliary/sundials_auxiliary.c
 recursive-include scikits *.pyx *.pxd *.pyf
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "cython"]


### PR DESCRIPTION
This adds support for [PEP 518](https://www.python.org/dev/peps/pep-0518/), which provides a way of specifying the build dependencies needed to build.