### PR TITLE
Add check-manifest and check-readme to tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
   - TOXENV=py27 SUNDIALS_VERSION='2.7.0'
   - TOXENV=py33 SUNDIALS_VERSION='2.7.0'
   - TOXENV=py34 SUNDIALS_VERSION='2.7.0'
+  - TOXENV=check-manifest SUNDIALS_VERSION='2.7.0'
+  - TOXENV=checkreadme SUNDIALS_VERSION='2.7.0'
 #  - TOXENV=py35
 # commented out because of https://github.com/travis-ci/travis-ci/issues/4794
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,11 @@
 include common.py scikits/odes/sundials/sundials_auxiliary/sundials_auxiliary.c
-recursive-include scikits *.pyx *.pxd *.pyf
+exclude scikits/odes/sundials/sundials/sundials_config.in
+recursive-include scikits *.pyx *.pxd *.pyf *.h
+
+include CONTRIBUTING.md README.md LICENSE.txt
+include tox.ini
+
+prune ci_support
+prune docs
+prune paper
+prune sphinxdoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
 [metadata]
 license_file = LICENSE.txt
 description-file = README.md
+
+[check-manifest]
+ignore =
+    .travis.yml
+    *.c

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,check-manifest,checkreadme
 skipsdist=True
 
 [testenv]
@@ -23,3 +23,25 @@ commands =
     py.test --pyargs scikits.odes {posargs}
 changedir =
     {toxworkdir}
+
+[testenv:check-manifest]
+deps=
+    check-manifest
+    numpy
+    cython
+setenv =
+    CHECK_MANIFEST=true
+commands=
+    check-manifest
+changedir =
+    {toxinidir}
+
+[testenv:checkreadme]
+deps=
+    readme_renderer
+    numpy
+    cython
+commands=
+    python setup.py check -s -r
+changedir =
+    {toxinidir}


### PR DESCRIPTION
Check-manifest checks that files are being correctly added to the sdist based on what's in git, and check-readme checks that the readme on PyPI renders properly (e.g. no rst syntax errors). This also includes fixes to the MANIFEST.in based on problems found via check-manifest.