### PR TITLE
FIX: Typo in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
     - $HOME/sundials
 
 env:
-      global::
+      global:
         # Doctr deploy key for bmcage/odes
         - secure: "aFKqG8ox8+mlfttD70nwHwkLcHz8PJM9K8dTxiXETAjOk+ZIc5g3tGTm1s9Gq+MpDVUgJmXJZBJituwmZnGB+1bwwLH71/ySMMYVkbvtK0kTDPj7qxuDkPKvj2SUIbC1MxiXXi1vK7zatdgHUDRQD4FZQsnbgNAtuQjMCe5hRJexXMUU21tZrMUFHJ6gKOjRExgLcnxE+j9dZbEYCSaumOY21LGOJXUv9RAqtcHC5VPvxrOG3jw7Q7yxFaPJrNBHoNc9bKQXfGLa/MV3YypOoGvIuj/+XhQzQ6jK3Vgp+LJ6t/nHkSs3Fwk3f8a0GyRGiAOZf36jb3BKK14zBmUak8bVbolJrYssMrFgK2bzRuEB37ZUejpuQ1vlH0fWJpFvAIgG1H3FUVasiu8fcq58Bvg6WHYkc1Av7M4HbKeCCaHTlM/SSp0iGJPXxokf3k/NFOwe0lFByYFzYv8aGYh4x3yT+HI1Ay0mTU3F+DJTn+KTVSmtmkrYEIq45aIhKiv7g0tYJYtFUt45J84TeMYtYJKMCwI5w1dzf1TwWtiAIxpJtbjF43cjHZN9kBhvhacjALrxAnK+nmE5yBmoB0xCMRj/TR31LIsDDyNy0yai/3FAdR+Uj1CihP+7Uokl+4nAnQpeCe6MMk+13CNkBBv2rFx0f2R9ZMKHzf1X1Y42WRc="
         # Doctr deploy key for aragilar/odes


### PR DESCRIPTION
It looks like the api docs aren't building due to the extra ':' in the travis config (found using https://lint.travis-ci.org/).