### PR TITLE
Update release instructions caused by recent changes.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -7,7 +7,7 @@ Please note that all contributions are subject to our `code of conduct <https://
 
 Reporting Bugs
 --------------
-``odes`` bug tracker is on `GitHub <https://github.com/bmcage/odes>`_.
+``odes`` bug tracker is on GitHub_.
 
 When reporting bugs, please include the versions of Python, ``odes`` and SUNDIALS,
 as well as which OS this appears on.
@@ -43,21 +43,84 @@ Please submit extra jupyter notebook examples of usage of ``odes``. Example
 notebooks should go in ``ipython_examples``, and add a short description to
 ``ipython_examples/README.md``.
 
+Building the Docs
+-----------------
+
+The documentation for ``odes`` is split into two parts, the main docs (of which
+this is a part), and the API docs. Both the main docs and API docs use sphinx_
+to build the docs, and running ``make html`` inside either of the associated
+directories will cause sphinx to create a html version of the docs.
+
+The main docs are located in the ``docs`` directory, and the requirements for
+building it are in ``docs/requirements.txt``.
+
+The API docs are located in the ``apidocs`` directory, and the requirements for
+building it are in ``apidocs/requirements.txt``.
+
+
 Creating a New Release
 ----------------------
 
-1. Set in ``common.py`` version string and ``DEV=False``, commit this.
-2. On GitHub, `draft a new release <https://github.com/bmcage/odes/releases>`_ by clicking the appropriate button. Give correct version number, and hit release. This will upload the release for a DOI to `Zenodo <https://zenodo.org>`_ as draft.
-3. Go to uploads in `Zenodo <https://zenodo.org>`_, edit the uploaded new release, save and hit the publish button. This will generate a DOI.
-4. Update to PyPI: ``python setup.py sdist --formats=gztar register upload``
-5. Update version string to a higher number in ``common.py``, and ``DEV=True``, next copy the DOI badge of Zenodo in the ``README.md``, commit these two files.
+There are five steps to creating a new ``odes`` release:
 
-For the documentation, you need following packages::
+1. Make a non-development version.
+2. Create a new release on GitHub_.
+3. Publish the new release on Zenodo_.
+4. Upload the new release to PyPI_.
+5. Bump the version to the next development version.
 
-    sudo apt-get install python-sphinx python-numpydoc python-mock
+The main docs should automatically build on readthedocs_, and the API docs should
+be built by doctr_. You should check that the docs have updated once you have
+make the release.
 
-After local install, create the new documentation via
+Making a non-development version
+................................
 
-1. Go to the sphinx directory: ``cd sphinxdoc``
-2. Create the documentation: ``make html``
-3. Upload the new html doc.
+To make a non-development version, inside ``common.py`` change ``DEV=True`` to ``DEV=False``, and if needed, modify ``MAJOR``, ``MINOR`` and ``MICRO`` to set the new release version.
+Then commit only these changes and push them to the main repository (bmcage/odes).
+
+Creating a new release on GitHub_
+.................................
+
+On GitHub, `draft a new release <https://github.com/bmcage/odes/releases>`_ by clicking the appropriate button. Use the version number from the non-development commit as the title, and hit release. This will upload the release for a DOI to Zenodo_ as draft.
+
+Publishing the new release on Zenodo_
+.....................................
+
+Go to uploads in Zenodo_, edit the uploaded new release, adding addition information as needed such as ORCID_, save and hit the publish button. This will generate a DOI.
+
+Uploading the new release to PyPI_
+..................................
+
+Make sure the current checkout is the non-development commit. To make sure no
+additional changes are included in the release, run::
+
+    git stash save --no-keep-index --all
+
+This saves the current working directory, then cleans it. The changes can be
+retrieved by running ``git stash pop`` (but you should not do this until the
+end).
+
+In the cleaned repository, run::
+
+    python setup.py sdist --formats=gztar
+
+which creates a ``dist`` directory containing a ``tar.gz`` file, the sdist for
+the release. To upload the sdist to PyPI_, run::
+
+    twine upload dist/*
+
+See https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi for more information about uploading to PyPI_.
+
+Bumping the version to the next development version
+...................................................
+
+Modify ``MAJOR``, ``MINOR`` and ``MICRO`` in ``common.py`` to a later version (increasing ``MICRO`` by 1 is sufficient). Also in ``common.py``, change back to ``DEV=True``. Finally, copy the DOI badge of of the latest release from Zenodo_ to the ``README.md``, and commit only these two files. You can now run ``git stash pop`` to retrieve what you were working on.
+
+.. _Zenodo: https://zenodo.org
+.. _Github: https://github.com/bmcage/odes
+.. _PyPI: https://pypi.org
+.. _readthedocs: https://readthedocs.org
+.. _doctr: https://drdoctr.github.io/doctr/
+.. _ORCID: https://orcid.org/
+.. _sphinx: http://www.sphinx-doc.org/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,1 @@
 sphinx>=1.3
-mock


### PR DESCRIPTION
I went with updating the current instructions, rather than creating a new file (it's more nicely rendered). I've added in more detail about individual steps. I didn't go into too much detail about what should go in the description for the github release, nor what exactly should be added to the zenodo release (the matplotlib release guide is really detailed, and can provides ideas for other things we may want to add to the release process with scripts https://matplotlib.org/devel/release_guide.html).

If you think we should split this out, I can do that also.