### PR TITLE
Fix building cvode interface on cython 0.28

### DIFF
--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1615,12 +1615,14 @@ cdef class CVODE:
         cdef unsigned int idx = 1 # idx == 0 is IC
         cdef unsigned int last_idx = np.alen(tspan)
         cdef DTYPE_t t
-        cdef int flag
+        cdef int flag = 0
         cdef void *cv_mem = self._cv_mem
         cdef realtype t_out
         cdef N_Vector y  = self.y
         cdef CV_ContinuationFunction onroot = self.options['onroot']
         cdef CV_ContinuationFunction ontstop = self.options['ontstop']
+        cdef object y_err
+        cdef object t_err
 
         y_last   = np.empty(np.shape(y0), DTYPE)
         t = tspan[idx]


### PR DESCRIPTION
Something (I'm not entirely sure what, the changelog doesn't provide anything relevant) changed in cython 0.28, which causes cython to fail to build the cvode interface. This small patch fixes this (and possibly do a point release just to fix this).