### PR TITLE
Skip running doctr as needed so CI doesn't always fail

### DIFF
--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1615,12 +1615,14 @@ cdef class CVODE:
         cdef unsigned int idx = 1 # idx == 0 is IC
         cdef unsigned int last_idx = np.alen(tspan)
         cdef DTYPE_t t
-        cdef int flag
+        cdef int flag = 0
         cdef void *cv_mem = self._cv_mem
         cdef realtype t_out
         cdef N_Vector y  = self.y
         cdef CV_ContinuationFunction onroot = self.options['onroot']
         cdef CV_ContinuationFunction ontstop = self.options['ontstop']
+        cdef object y_err
+        cdef object t_err
 
         y_last   = np.empty(np.shape(y0), DTYPE)
         t = tspan[idx]

--- a/upload_api_docs.sh
+++ b/upload_api_docs.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+set -e
+
+if [ "$TRAVIS_REPO_SLUG" = "bmcage/odes" -o "$DOCTR_DEPLOY" ]; then
+    deploy="true"
+else
+    deploy="false"
+fi
+
+
 if [ -z "$TRAVIS_TAG" ]; then
     DEPLOY_DIR=dev;
 else
@@ -8,4 +17,8 @@ fi
 
 make -C apidocs html
 
-doctr deploy --no-require-master --build-tags --command "$VIRTUAL_ENV/bin/python build_index.py" --built-docs apidocs/_build/html $DEPLOY_DIR
+if [ $deploy = "true" ]; then
+    doctr deploy --no-require-master --build-tags --command "$VIRTUAL_ENV/bin/python build_index.py" --built-docs apidocs/_build/html $DEPLOY_DIR
+else
+    echo 'Not deploying docs, set DOCTR_DEPLOY to do deployment of docs'
+fi


### PR DESCRIPTION
Travis is going to fail on running the doctr build unless it's running against 'bmcage/odes' (as it can't push otherwise), so skip this (the docs will build automatically still, and there's an environment variable to override.

Includes #72 as otherwise everything will fail.