### PR TITLE
Issue 77 expose IDA's iterative linsolver interface

### DIFF
--- a/scikits/odes/sundials/c_ida.pxd
+++ b/scikits/odes/sundials/c_ida.pxd
@@ -178,12 +178,12 @@ cdef extern from "ida/ida_spils.h":
                                         realtype c_j, realtype delta, void *user_data)                
     ctypedef int (*IDASpilsJacTimesSetupFn)(realtype tt, N_Vector yy,
                                        N_Vector yp, N_Vector rr,
-                                       realtype c_j, void *user_data)
+                                       realtype c_j, void *user_data) except? -1
     ctypedef int (*IDASpilsJacTimesVecFn)(realtype tt,
                                           N_Vector yy, N_Vector yp, N_Vector rr,
                                           N_Vector v, N_Vector Jv,
                                           realtype c_j, void *user_data,
-                                          N_Vector tmp1, N_Vector tmp2)
+                                          N_Vector tmp1, N_Vector tmp2)  except? -1
 
     int IDASpilsSetLinearSolver(void *ida_mem, SUNLinearSolver LS)
     int IDASpilsSetPreconditioner(void *ida_mem,

--- a/scikits/odes/sundials/ida.pxd
+++ b/scikits/odes/sundials/ida.pxd
@@ -68,6 +68,44 @@ cdef class IDA_WrapPrecSolveFunction(IDA_PrecSolveFunction):
     cdef int with_userdata
     cpdef set_prec_solvefn(self, object prec_solvefn)
 
+cdef class IDA_JacTimesVecFunction:
+    cpdef int evaluate(self,
+                       DTYPE_t t,
+                       np.ndarray[DTYPE_t, ndim=1] yy,
+                       np.ndarray[DTYPE_t, ndim=1] yp,
+                       np.ndarray[DTYPE_t, ndim=1] rr,
+                       np.ndarray[DTYPE_t, ndim=1] v,
+                       np.ndarray[DTYPE_t, ndim=1] Jv,
+                       DTYPE_t cj,
+                       object userdata = *) except? -1
+
+cdef class IDA_WrapJacTimesVecFunction(IDA_JacTimesVecFunction):
+    cpdef object _jac_times_vecfn
+    cdef int with_userdata
+    cpdef set_jac_times_vecfn(self, object jac_times_vecfn)
+
+cdef class IDA_JacTimesSetupFunction:
+    cpdef int evaluate(self,
+                       DTYPE_t tt,
+                       np.ndarray[DTYPE_t, ndim=1] yy,
+                       np.ndarray[DTYPE_t, ndim=1] yp,
+                       np.ndarray[DTYPE_t, ndim=1] rr,
+                       DTYPE_t cj,
+                       object userdata = *) except? -1
+
+cdef class IDA_WrapJacTimesSetupFunction(IDA_JacTimesSetupFunction):
+    cpdef object _jac_times_setupfn
+    cdef int with_userdata
+    cpdef set_jac_times_setupfn(self, object jac_times_setupfn)
+
+    cpdef int evaluate(self,
+                       DTYPE_t tt,
+                       np.ndarray[DTYPE_t, ndim=1] yy,
+                       np.ndarray[DTYPE_t, ndim=1] yp,
+                       np.ndarray[DTYPE_t, ndim=1] rr,
+                       DTYPE_t cj,
+                       object userdata = *) except? -1
+
 cdef class IDA_ContinuationFunction:
     cpdef object _fn
     cpdef int evaluate(self, DTYPE_t t, np.ndarray[DTYPE_t, ndim=1] y,
@@ -91,12 +129,15 @@ cdef class IDA_WrapErrHandler(IDA_ErrHandler):
 
 
 cdef class IDA_data:
-    cdef np.ndarray yy_tmp, yp_tmp, residual_tmp, jac_tmp, g_tmp, z_tmp, rvec_tmp
+    cdef np.ndarray yy_tmp, yp_tmp, residual_tmp, jac_tmp
+    cdef np.ndarray g_tmp, z_tmp, rvec_tmp, v_tmp
     cdef IDA_RhsFunction res
     cdef IDA_JacRhsFunction jac
     cdef IDA_RootFunction rootfn
     cdef IDA_PrecSetupFunction prec_setupfn
     cdef IDA_PrecSolveFunction prec_solvefn
+    cdef IDA_JacTimesVecFunction jac_times_vecfn
+    cdef IDA_JacTimesSetupFunction jac_times_setupfn
     cdef bint parallel_implementation
     cdef object user_data
     cdef IDA_ErrHandler err_handler

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -771,6 +771,8 @@ cdef class IDA_data:
         self.g_tmp = None
         self.z_tmp = None
         self.rvec_tmp = None
+        self.v_tmp = np.empty(N, DTYPE)
+        self.z_tmp = np.empty(N, DTYPE)
 
 cdef class IDA:
 
@@ -812,6 +814,8 @@ cdef class IDA:
             'precond_type': 'NONE',
             'prec_setupfn': None,
             'prec_solvefn': None,
+            'jac_times_vecfn': None,
+            'jac_times_setupfn': None,
             'err_handler': None,
             'err_user_data': None,
             'old_api': None,

--- a/scikits/odes/tests/test_dae.py
+++ b/scikits/odes/tests/test_dae.py
@@ -35,6 +35,8 @@ class TestDae(TestCase):
         jac_times_vec2 = None
         jac_times_setupfn = None
 
+        # restrict to 'ida' method since jacobian function below
+        # follows the ida interface
         if jac is not None and integrator == 'ida':
             def jac_times_vec(tt, yy, yp, rr, v, Jv, cj):
                 J = zeros((len(yy), len(yy)), DTYPE)
@@ -55,6 +57,7 @@ class TestDae(TestCase):
 
         igs = [dae(integrator, res, jacfn=jac, old_api=old_api)]
 
+        # if testing 'ida' then try the iterative linsolvers as well
         if integrator == 'ida':
             igs.append(
                 dae(integrator, res, linsolver='spgmr',


### PR DESCRIPTION
1. copy-and-edit CV_JacTimesVecFunction and CV_JacTimesSetupFunction from CVODE code
2. edit `test_dae.py` to test iterative linsolver 'spgmr' along with 'ida' method, with and without supplied jacobian

See #77 