### PR TITLE
common_defs.pxd: remove inline modifier

### DIFF
--- a/scikits/odes/sundials/common_defs.pxd
+++ b/scikits/odes/sundials/common_defs.pxd
@@ -20,10 +20,10 @@ ELIF SUNDIALS_INDEX_TYPE == "int64":
 ELSE:
     ctypedef np.int64_t INDEX_TYPE_t
 
-cdef inline int nv_s2ndarray(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1
-cdef inline int ndarray2nv_s(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1
+cdef int nv_s2ndarray(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1
+cdef int ndarray2nv_s(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1
 
-cdef inline int SUNMatrix2ndarray(SUNMatrix m, np.ndarray a) except? -1
-cdef inline int ndarray2SUNMatrix(SUNMatrix m, np.ndarray a) except? -1
+cdef int SUNMatrix2ndarray(SUNMatrix m, np.ndarray a) except? -1
+cdef int ndarray2SUNMatrix(SUNMatrix m, np.ndarray a) except? -1
 
 cdef ensure_numpy_float_array(object value)

--- a/scikits/odes/sundials/common_defs.pyx
+++ b/scikits/odes/sundials/common_defs.pyx
@@ -118,7 +118,7 @@ cdef inline N_Vector spfgmr_vtemp(SpfgmrMem mem):
     return mem.vtemp
 
 # Public functions
-cdef inline int nv_s2ndarray(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1:
+cdef int nv_s2ndarray(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1:
     """ copy a serial N_Vector v to a numpy array a """
     cdef sunindextype N, i
     N = nv_length_s(v)
@@ -127,7 +127,7 @@ cdef inline int nv_s2ndarray(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? 
     for i in range(N):
       a[i] = get_nv_ith_s(v_data, i)
 
-cdef inline int ndarray2nv_s(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1:
+cdef int ndarray2nv_s(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? -1:
     """ copy a numpy array a to a serial N_Vector v t"""
     cdef unsigned int N, i
     N = nv_length_s(v)
@@ -136,7 +136,7 @@ cdef inline int ndarray2nv_s(N_Vector v, np.ndarray[DTYPE_t, ndim=1] a) except? 
     for i in range(N):
       set_nv_ith_s(v_data, i, a[i])
 
-cdef inline int SUNMatrix2ndarray(SUNMatrix m, np.ndarray a) except? -1:
+cdef int SUNMatrix2ndarray(SUNMatrix m, np.ndarray a) except? -1:
     """ copy a SUNMatrix m to a numpy array a """
     cdef sunindextype N, M, i, j, ml, mu, stride
     cdef nv_content_data_s v_col
@@ -163,7 +163,7 @@ cdef inline int SUNMatrix2ndarray(SUNMatrix m, np.ndarray a) except? -1:
     else:
         raise NotImplementedError("SUNMatrix type not supported")
 
-cdef inline int ndarray2SUNMatrix(SUNMatrix m, np.ndarray a) except? -1:
+cdef int ndarray2SUNMatrix(SUNMatrix m, np.ndarray a) except? -1:
     """ copy a numpy array a to a SUNMatrix m"""
     cdef sunindextype N, M, i, j, ml, mu, stride
     cdef nv_content_data_s v_col


### PR DESCRIPTION
This causes compilation errors with Clang, for example when building on MacOS.

See https://grokbase.com/t/gg/cython-users/13987sentw/cython-inline-causing-errors-on-macos-with-clang#20130908e6otbth2q2uhx5hqe7ujqsrxe4

I successfully ran the testsuite on it after applying the change, both on x86_64-linux and MacOS.