### PR TITLE
Provide user_data for rhs, jac and err calls when using IDA

### DIFF
--- a/scikits/odes/dopri5.py
+++ b/scikits/odes/dopri5.py
@@ -43,8 +43,12 @@ dop853
 
 from __future__ import print_function
 
+import sys
 from collections import namedtuple
-from enum import IntEnum
+try:
+    from enum import IntEnum
+except ImportError:
+    from enum34 import IntEnum
 from warnings import warn
 
 import numpy as np

--- a/scikits/odes/sundials/__init__.py
+++ b/scikits/odes/sundials/__init__.py
@@ -51,16 +51,12 @@ def _get_num_args(func):
     """
     Python 2/3 compatible method of getting number of args that `func` accepts
     """
-    if hasattr(inspect, "signature"):
-        sig = inspect.signature(func)
-        numargs = 0
-        for param in sig.parameters.values():
-            if param.kind in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.VAR_POSITIONAL,
-            ):
-                numargs += 1
-        return numargs
+    if hasattr(inspect, "getfullargspec"):
+        argspec = inspect.getfullargspec(func)
     else:
-        return len(inspect.getargspec(func).args)
+        argspec = inspect.getargspec(func)
+    arg_cnt = 0
+    for arg in argspec.args:
+        if arg not in ("self", "cls"):
+            arg_cnt += 1
+    return arg_cnt

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1,7 +1,10 @@
 # cython: embedsignature=True
 from cpython.exc cimport PyErr_CheckSignals
 from collections import namedtuple
-from enum import IntEnum
+try:
+    from enum import IntEnum
+except ImportError:
+    from enum34 import IntEnum
 import inspect
 from warnings import warn
 

--- a/scikits/odes/sundials/cvodes.pyx
+++ b/scikits/odes/sundials/cvodes.pyx
@@ -1,7 +1,10 @@
 # cython: embedsignature=True
 from cpython.exc cimport PyErr_CheckSignals
 from collections import namedtuple
-from enum import IntEnum
+try:
+    from enum import IntEnum
+except ImportError:
+    from enum34 import IntEnum
 import inspect
 from warnings import warn
 

--- a/scikits/odes/sundials/ida.pxd
+++ b/scikits/odes/sundials/ida.pxd
@@ -32,7 +32,9 @@ cdef class IDA_JacRhsFunction:
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] residual,
                        DTYPE_t cj,
-                       np.ndarray[DTYPE_t, ndim=2] J) except? -1
+                       np.ndarray[DTYPE_t, ndim=2] J,
+                       object userdata = *) except? -1
+
 
 cdef class IDA_WrapJacRhsFunction(IDA_JacRhsFunction):
     cdef object _jacfn

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -130,7 +130,8 @@ cdef class IDA_RhsFunction:
     recoverable failure, negative for unrecoverable failure (as per IDA
     documentation).
     """
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] result,
@@ -142,16 +143,14 @@ cdef class IDA_WrapRhsFunction(IDA_RhsFunction):
         """
         set some residual equations as a ResFunction executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(resfn)
-        if nrarg > 5:
-            # hopefully a class method
+        if _get_num_args(resfn) == 5:
             self.with_userdata = 1
-        elif nrarg == 5 and inspect.isfunction(resfn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._resfn = resfn
 
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] result,
@@ -200,7 +199,8 @@ cdef class IDA_RootFunction:
     Note that evaluate must return a integer, 0 for success, non-zero for error
     (as per IDA documentation).
     """
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] g,
@@ -212,16 +212,14 @@ cdef class IDA_WrapRootFunction(IDA_RootFunction):
         """
         set root-ing condition(equations) as a RootFunction executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(rootfn)
-        if nrarg > 5:
-            #hopefully a class method, self gives 5 arg!
+        if _get_num_args(rootfn) == 5:
             self.with_userdata = 1
-        elif nrarg == 5 and inspect.isfunction(rootfn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._rootfn = rootfn
 
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] g,
@@ -271,12 +269,14 @@ cdef class IDA_JacRhsFunction:
     recoverable failure, negative for unrecoverable failure (as per IDA
     documentation).
     """
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] residual,
                        DTYPE_t cj,
-                       np.ndarray J) except? -1:
+                       np.ndarray J,
+                       object userdata = None) except? -1:
         """
         Returns the Jacobi matrix of the residual function, as
             d(res)/d y + cj d(res)/d ydot
@@ -294,24 +294,29 @@ cdef class IDA_WrapJacRhsFunction(IDA_JacRhsFunction):
         """
         Set some jacobian equations as a JacResFunction executable class.
         """
+        if _get_num_args(jacfn) == 7:
+            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._jacfn = jacfn
 
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        np.ndarray[DTYPE_t, ndim=1] residual,
                        DTYPE_t cj,
-                       np.ndarray J) except? -1:
+                       np.ndarray J,
+                       object userdata = None) except? -1:
         """
         Returns the Jacobi matrix (for dense the full matrix, for band only
         bands. Result has to be stored in the variable J, which is preallocated
         to the corresponding size.
         """
-##        if self.with_userdata == 1:
-##            self._jacfn(t, y, ydot, cj, J, userdata)
-##        else:
-##            self._jacfn(t, y, ydot, cj, J)
-        user_flag = self._jacfn(t, y, ydot, residual, cj, J)
+        if self.with_userdata == 1:
+            user_flag = self._jacfn(t, y, ydot, residual, cj, J, userdata)
+        else:
+            user_flag = self._jacfn(t, y, ydot, residual, cj, J)
         if user_flag is None:
             user_flag = 0
         return user_flag
@@ -358,7 +363,8 @@ cdef class IDA_PrecSetupFunction:
     recoverable failure, negative for unrecoverable failure (as per CVODE
     documentation).
     """
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] yp,
                        np.ndarray[DTYPE_t, ndim=1] rr,
@@ -380,16 +386,14 @@ cdef class IDA_WrapPrecSetupFunction(IDA_PrecSetupFunction):
         set a precondititioning setup method as a IDA_PrecSetupFunction
         executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(prec_setupfn)
-        if nrarg > 5:
-            #hopefully a class method, self gives 6 arg!
+        if _get_num_args(prec_setupfn) == 6:
             self.with_userdata = 1
-        elif nrarg == 5 and inspect.isfunction(prec_setupfn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._prec_setupfn = prec_setupfn
 
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] yp,
                        np.ndarray[DTYPE_t, ndim=1] rr,
@@ -436,7 +440,8 @@ cdef class IDA_PrecSolveFunction:
     recoverable failure, negative for unrecoverable failure (as per CVODE
     documentation).
     """
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] yp,
                        np.ndarray[DTYPE_t, ndim=1] r,
@@ -463,16 +468,14 @@ cdef class IDA_WrapPrecSolveFunction(IDA_PrecSolveFunction):
         set a precondititioning solve method as a IDA_PrecSolveFunction
         executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(prec_solvefn)
-        if nrarg > 9:
-            #hopefully a class method, self gives 10 arg!
+        if _get_num_args(prec_solvefn) == 9:
             self.with_userdata = 1
-        elif nrarg == 9 and inspect.isfunction(prec_solvefn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._prec_solvefn = prec_solvefn
 
-    cpdef int evaluate(self, DTYPE_t t,
+    cpdef int evaluate(self,
+                       DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] yp,
                        np.ndarray[DTYPE_t, ndim=1] r,
@@ -570,13 +573,10 @@ cdef class IDA_WrapJacTimesVecFunction(IDA_JacTimesVecFunction):
         set a jacobian-times-vector method as a IDA_JacTimesVecFunction
         executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(jac_times_vecfn)
-        if nrarg > 8:
-            #hopefully a class method, self gives 9 arg!
+        if _get_num_args(jac_times_vecfn) == 8:
             self.with_userdata = 1
-        elif nrarg == 8 and inspect.isfunction(jac_times_vecfn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._jac_times_vecfn = jac_times_vecfn
 
     cpdef int evaluate(self,
@@ -658,13 +658,10 @@ cdef class IDA_WrapJacTimesSetupFunction(IDA_JacTimesSetupFunction):
         set a jacobian-times-vector method setup as a IDA_JacTimesSetupFunction
         executable class
         """
-        self.with_userdata = 0
-        nrarg = _get_num_args(jac_times_setupfn)
-        if nrarg > 6:
-            #hopefully a class method, self gives 7 arg!
+        if _get_num_args(jac_times_setupfn) == 6:
             self.with_userdata = 1
-        elif nrarg == 6 and inspect.isfunction(jac_times_setupfn):
-            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._jac_times_setupfn = jac_times_setupfn
 
     cpdef int evaluate(self,
@@ -737,10 +734,10 @@ cdef class IDA_WrapErrHandler(IDA_ErrHandler):
         """
         set some (c/p)ython function as the error handler
         """
-        nrarg = _get_num_args(err_handler)
-        self.with_userdata = (nrarg > 5) or (
-            nrarg == 5 and inspect.isfunction(err_handler)
-        )
+        if _get_num_args(err_handler) == 5:
+            self.with_userdata = 1
+        else:
+            self.with_userdata = 0
         self._err_handler = err_handler
 
     cpdef evaluate(self,

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -1,7 +1,10 @@
 # cython: embedsignature=True
 from cpython.exc cimport PyErr_CheckSignals
 from collections import namedtuple
-from enum import IntEnum
+try:
+    from enum import IntEnum
+except ImportError:
+    from enum34 import IntEnum
 import inspect
 from warnings import warn
 

--- a/scikits/odes/sundials/ida.pyx
+++ b/scikits/odes/sundials/ida.pyx
@@ -344,7 +344,7 @@ cdef int _jacdense(realtype tt, realtype cj,
         nv_s2ndarray(yy, yy_tmp)
         nv_s2ndarray(yp, yp_tmp)
         nv_s2ndarray(rr, residual_tmp)
-    user_flag = aux_data.jac.evaluate(tt, yy_tmp, yp_tmp, residual_tmp, cj, jac_tmp)
+    user_flag = aux_data.jac.evaluate(tt, yy_tmp, yp_tmp, residual_tmp, cj, jac_tmp, aux_data.user_data)
 
     if parallel_implementation:
         raise NotImplemented

--- a/scikits/odes/sundials/idas.pyx
+++ b/scikits/odes/sundials/idas.pyx
@@ -1,7 +1,10 @@
 # cython: embedsignature=True
 from cpython.exc cimport PyErr_CheckSignals
 from collections import namedtuple
-from enum import IntEnum
+try:
+    from enum import IntEnum
+except ImportError:
+    from enum34 import IntEnum
 import inspect
 from warnings import warn
 

--- a/scikits/odes/tests/test_dae.py
+++ b/scikits/odes/tests/test_dae.py
@@ -266,9 +266,11 @@ class SimpleOscillatorJacIDA(SimpleOscillator):
 
 class SimpleOscillatorIDAUserData(SimpleOscillatorJacIDA):
     def res(self, t, z, zp, res, user_data):
+        assert user_data is not None
         SimpleOscillatorJacIDA.res(self, t, z, zp, res)
 
     def jac(self, t, y, yp, residual, cj, jac, user_data):
+        assert user_data is not None
         SimpleOscillatorJacIDA.jac(self, t, y, yp, residual, cj, jac)
 
 

--- a/scikits/odes/tests/test_dae.py
+++ b/scikits/odes/tests/test_dae.py
@@ -9,7 +9,7 @@ import platform
 import scipy.sparse as sparse
 
 from numpy import (arange, zeros, array, dot, sqrt, cos, sin, allclose,
-                    empty, alen)
+                   empty)
 
 from numpy.testing import TestCase, run_module_suite
 from scipy.integrate import ode as Iode
@@ -75,8 +75,8 @@ class TestDae(TestCase):
 
         for ig in igs:
             ig.set_options(old_api=old_api, **integrator_params)
-            z = empty((1+len(problem.stop_t),alen(problem.z0)), DTYPE)
-            zprime = empty((1+len(problem.stop_t),alen(problem.z0)), DTYPE)
+            z = empty((1+len(problem.stop_t), len(problem.z0)), DTYPE)
+            zprime = empty((1+len(problem.stop_t), len(problem.z0)), DTYPE)
             ist = ig.init_step(0., problem.z0, problem.zprime0, z[0], zprime[0])
             i=1
             for time in problem.stop_t:

--- a/scikits/odes/tests/test_dae.py
+++ b/scikits/odes/tests/test_dae.py
@@ -14,7 +14,44 @@ from numpy import (arange, zeros, array, dot, sqrt, cos, sin, allclose,
 from numpy.testing import TestCase, run_module_suite
 from scipy.integrate import ode as Iode
 from scikits.odes import ode,dae
+from scikits.odes.sundials import _get_num_args
 from scikits.odes.sundials.common_defs import DTYPE
+
+
+class TestGetNumArgs(TestCase):
+    """
+    Check the correct number for `_get_num_args`
+    """
+    def test_functions(self):
+        def _func(a, b, c):
+            pass
+        assert _get_num_args(_func) == 3
+
+        def _func(a, b, c=None):
+            pass
+        # kwd args should not make a difference
+        assert _get_num_args(_func) == 3
+
+    def test_methods(self):
+        class C:
+            @ classmethod
+            def class_method(cls, a, b):
+                pass
+
+            @ staticmethod
+            def static_method(a, b):
+                pass
+
+            def method(self, a, b):
+                pass
+
+        # self should not be counted
+        assert _get_num_args(C.method) == 2
+        # static methods should also work
+        assert _get_num_args(C.static_method) == 2
+        # class methods should also work
+        assert _get_num_args(C.class_method) == 2
+
 
 class TestDae(TestCase):
     """
@@ -333,3 +370,6 @@ if __name__ == "__main__":
         test.test_lsodi()
         test.test_ida_old_api()
         test.test_ida()
+        test = TestGetNumArgs()
+        test.test_functions()
+        test.test_methods()

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ passenv=
 deps =
     py27: enum34
     numpy
+    scipy
     cython
     nose
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ passenv=
     PIP_VERBOSE
     PYTHONFAULTHANDLER
 deps =
+    py27: enum34
     numpy
     cython
     nose


### PR DESCRIPTION
This PR fixes a bug where the user could provide `user_data` when initializing the IDA solver but that data would never be provided when the actual functions were called within a solver step.

Some modifications to the argument-counting logic where made and tests have been added for the most important cases.

Furthermore, some unrelated changes were made to get all tests running. The tox output reads:
```
  py27: commands succeeded
ERROR:  py35: InterpreterNotFound: python3.5
  py36: commands succeeded
  py37: commands succeeded
  py39: commands succeeded
  check-manifest: commands succeeded
  checkreadme: commands succeeded
  docs: commands succeeded
```
(I do not have Python 3.5 installed on my machine as it is EoL since January this year.)