### PR TITLE
Add python 3.8 and 3.9 to tox/CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,12 @@ matrix:
     - python: 3.7
       env:
       - TOXENV=py37 SUNDIALS_VERSION='5.1.0'
+    - python: 3.8
+      env:
+      - TOXENV=py38 SUNDIALS_VERSION='5.1.0'
+    - python: 3.9
+      env:
+      - TOXENV=py39 SUNDIALS_VERSION='5.1.0'
     - python: 3.7
       env:
       - TOXENV=doctr SUNDIALS_VERSION='5.1.0'

--- a/common.py
+++ b/common.py
@@ -39,6 +39,8 @@ CLASSIFIERS = [
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
 ]
 
 def build_verstring():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,check-manifest,checkreadme,docs
+envlist = py27,py35,py36,py37,py38,py39,check-manifest,checkreadme,docs
 setenv = LANG=en_US.UTF-8 LC_ALL= en_US.UTF-8
 #skipsdist=True
 


### PR DESCRIPTION
This adds the latest python releases to the CI. At some point we may want to drop some of older releases.