### PR TITLE
New features

### DIFF
--- a/scikits/odes/sundials/cvode.pxd
+++ b/scikits/odes/sundials/cvode.pxd
@@ -23,18 +23,19 @@ cdef class CV_RootFunction:
 
 cdef class CV_WrapRootFunction(CV_RootFunction):
     cdef object _rootfn
-    cdef int with_userdata
+    cdef public int with_userdata
     cpdef set_rootfn(self, object rootfn)
 
 cdef class CV_JacRhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] fy,
-                       np.ndarray[DTYPE_t, ndim=2] J) except? -1
+                       np.ndarray[DTYPE_t, ndim=2] J,
+                       object userdata = *) except? -1
 
 cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
     cdef public object _jacfn
-    cdef int with_userdata
+    cdef public int with_userdata
     cpdef set_jacfn(self, object jacfn)
 
 cdef class CV_PrecSetupFunction:
@@ -128,7 +129,7 @@ cdef class CVODE:
     cdef N_Vector atol
     cdef void* _cv_mem
     cdef SUNContext sunctx
-    cdef dict options
+    cdef public dict options
     cdef bint parallel_implementation, initialized, _old_api, _step_compute, _validate_flags
     cdef CV_data aux_data
 

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -257,7 +257,8 @@ cdef class CV_JacRhsFunction:
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] fy,
-                       np.ndarray[DTYPE_t, ndim=2] J) except? -1:
+                       np.ndarray[DTYPE_t, ndim=2] J,
+                       object userdata = None) except? -1:
         """
         Returns the Jacobi matrix of the right hand side function, as
             d(rhs)/d y
@@ -275,22 +276,30 @@ cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
         """
         Set some jacobian equations as a JacRhsFunction executable class.
         """
+        self.with_userdata = 0
+        self._jacfn = jacfn
+        nrarg = _get_num_args(jacfn)
+        if nrarg > 5:
+            #hopefully a class method, self gives 6 arg!
+            self.with_userdata = 1
+        elif nrarg == 5 and inspect.isfunction(jacfn):
+            self.with_userdata = 1
         self._jacfn = jacfn
 
     cpdef int evaluate(self, DTYPE_t t,
                        np.ndarray[DTYPE_t, ndim=1] y,
                        np.ndarray[DTYPE_t, ndim=1] fy,
-                       np.ndarray J) except? -1:
+                       np.ndarray J,
+                       object userdata = None) except? -1:
         """
         Returns the Jacobi matrix (for dense the full matrix, for band only
         bands. Result has to be stored in the variable J, which is preallocated
         to the corresponding size.
         """
-##        if self.with_userdata == 1:
-##            self._jacfn(t, y, ydot, cj, J, userdata)
-##        else:
-##            self._jacfn(t, y, ydot, cj, J)
-        user_flag = self._jacfn(t, y, fy, J)
+        if self.with_userdata == 1:
+            user_flag = self._jacfn(t, y, fy, J, userdata)
+        else:
+            user_flag = self._jacfn(t, y, fy, J)
 
         if user_flag is None:
             user_flag = 0
@@ -318,7 +327,7 @@ cdef int _jacdense(sunrealtype tt,
         ff_tmp = aux_data.z_tmp
         nv_s2ndarray(ff, ff_tmp)
 
-    user_flag = aux_data.jac.evaluate(tt, yy_tmp, ff_tmp, jac_tmp)
+    user_flag = aux_data.jac.evaluate(tt, yy_tmp, ff_tmp, jac_tmp, aux_data.user_data,)
 
     if parallel_implementation:
         raise NotImplemented
@@ -1644,8 +1653,12 @@ cdef class CVODE:
             else:
                 _test = np.empty((len(y0), len(y0)), DTYPE)
             _fy_test = np.zeros(len(y0), DTYPE)
-            jac._jacfn(t0, y0, _fy_test, _test)
+            if jac.with_userdata:
+                jac._jacfn(t0, y0, _fy_test, _test, opts['user_data'])
+            else:
+                jac._jacfn(t0, y0, _fy_test, _test)
             _test = None
+            _fy_test = None
 
         #now we initialize storage which is persistent over steps
         self.t_roots = []
@@ -1895,6 +1908,14 @@ cdef class CVODE:
             flag, t_retn, y_retn, t_err, y_err, self.t_roots, self.y_roots,
             self.t_tstop, self.y_tstop,
         )
+
+    def rootinfo(self):
+        #cdef int[self.options['nr_rootfns']] rootsfound
+        N = self.options['nr_rootfns']
+        cdef np.ndarray[int, ndim=1, mode='c'] rootsfound = np.empty(N, dtype=np.int32)
+        #cdef int rootsfound[N]
+        CVodeGetRootInfo(self._cv_mem, &rootsfound[0])
+        return rootsfound
 
 
     def step(self, DTYPE_t t, np.ndarray[DTYPE_t, ndim=1] y_retn = None):

--- a/scikits/odes/sundials/cvode.pyx
+++ b/scikits/odes/sundials/cvode.pyx
@@ -1077,7 +1077,7 @@ cdef class CVODE:
         if not supress_supported_check:
             for opt in options.keys():
                 if not opt in ['atol', 'rtol', 'tstop', 'rootfn', 'nr_rootfns',
-                               'verbosity', 'one_step_compute']:
+                               'verbosity', 'one_step_compute', 'max_step_size']:
                     raise ValueError("Option '%s' can''t be set runtime." % opt)
 
         # Verbosity level
@@ -1181,7 +1181,7 @@ cdef class CVODE:
         if ('tstop' in options) and (options['tstop'] is not None):
             opts_tstop = options['tstop']
             self.options['tstop'] = opts_tstop
-            if (not opts_tstop is None) and (opts_tstop > 0.):
+            if (not opts_tstop is None):
                 flag = CVodeSetStopTime(cv_mem, <sunrealtype> opts_tstop)
                 if flag == CV_ILL_INPUT:
                     raise ValueError('CVodeSetStopTime::Stop value is beyond '


### PR DESCRIPTION
I made a few changes to the CVODE interface that I needed for a project that I wanted share with the main distribution in case it was of interest. Since I was merely prototyping I have several features/changes that committed on top of each other:

- make `options` dict and and `with_userdata` flag public (done for prototyping, not attached to this one)
- the ability to pass userdata to the `jacfn` (I did not actually end up using this for my project, but it seemed like someone else had it almost working)
- allow `max_step_size` to be changed after the solver has been instantiated (used in my project)
- allow arbitrary values of `tstop` option to be used rather than enforcing strictly positive (used in my project)
- adding a wrapper to the `CVodeGetRootInfo` method which "returns an array showing which functions were found to have a root" according to the [SUNDIALS docs](https://sundials.readthedocs.io/en/latest/cvode/Usage/index.html#c.CVodeGetRootInfo) (used in my project)

Are any/all of these changes of interest? If so, would a monolithic PR be acceptable or do they need to be split into individual PRs? Once the features are approved, I can update the docs and add tests as appropriate.

Best,
Ben
 