### PR TITLE
fixes #147: SUNDIALS_BLAS_LAPACK not present in sundials 6

### DIFF
--- a/packages/scikits-odes-sundials/setup_build.py
+++ b/packages/scikits-odes-sundials/setup_build.py
@@ -128,7 +128,7 @@ def get_sundials_config_pxi(include_dirs, dist):
     # Check for blas/lapack
     if check_macro_def(
         config_cmd,
-        "SUNDIALS_BLAS_LAPACK", headers=[SUNDIALS_CONFIG_H],
+        "SUNDIALS_BLAS_LAPACK_ENABLED", headers=[SUNDIALS_CONFIG_H],
         include_dirs=include_dirs
     ):
         has_lapack = True

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_sunlinsol.pxd
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_sunlinsol.pxd
@@ -63,7 +63,6 @@ IF SUNDIALS_BLAS_LAPACK:
         ctypedef _SUNLinearSolverContent_LapackDense *SUNLinearSolverContent_LapackDense
 
         SUNLinearSolver SUNLinSol_LapackDense(N_Vector y, SUNMatrix A, SUNContext sunctx)
-        SUNLinearSolver SUNLapackDense(N_Vector y, SUNMatrix A) #deprecated
 
         SUNLinearSolver_Type SUNLinSolGetType_LapackDense(SUNLinearSolver S)
         SUNLinearSolver_ID SUNLinSolGetID_LapackDense(SUNLinearSolver S)
@@ -87,7 +86,6 @@ IF SUNDIALS_BLAS_LAPACK:
         ctypedef _SUNLinearSolverContent_LapackBand *SUNLinearSolverContent_LapackBand
 
         SUNLinearSolver SUNLinSol_LapackBand(N_Vector y, SUNMatrix A, SUNContext sunctx)
-        SUNLinearSolver SUNLapackBand(N_Vector y, SUNMatrix A) # deprecated
 
         SUNLinearSolver_Type SUNLinSolGetType_LapackBand(SUNLinearSolver S)
         SUNLinearSolver_ID SUNLinSolGetID_LapackBand(SUNLinearSolver S)

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/cvode.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/cvode.pyx
@@ -1558,7 +1558,7 @@ cdef class CVODE(BaseSundialsSolver):
                 if SUNDIALS_BLAS_LAPACK:
                     if linsolver == 'lapackdense':
                         A = SUNDenseMatrix(N, N, self.sunctx)
-                        LS = SUNLapackDense(self.y0, A)
+                        LS = SUNLinSol_LapackDense(self.y0, A, self.sunctx)
                         # check if memory was allocated
                         if (A == NULL or LS == NULL):
                             raise ValueError('Could not allocate matrix or linear solver')
@@ -1574,7 +1574,7 @@ cdef class CVODE(BaseSundialsSolver):
                                              .format(flag))
                     elif linsolver == 'lapackband':
                         A = SUNBandMatrix(N, <int> opts['uband'], <int> opts['lband'], self.sunctx)
-                        LS = SUNLapackBand(self.y0, A)
+                        LS = SUNLinSol_LapackBand(self.y0, A, self.sunctx)
                         if (A == NULL or LS == NULL):
                             raise ValueError('Could not allocate matrix or linear solver')
                         flag = CVodeSetLinearSolver(cv_mem, LS, A)

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
@@ -1669,7 +1669,7 @@ cdef class IDA(BaseSundialsSolver):
             if SUNDIALS_BLAS_LAPACK:
                 if linsolver == 'lapackdense':
                     A = SUNDenseMatrix(N, N, self.sunctx)
-                    LS = SUNLapackDense(self.y0, A)
+                    LS = SUNLinSol_LapackDense(self.y0, A, self.sunctx)
                     # check if memory was allocated
                     if (A == NULL or LS == NULL):
                         raise ValueError('Could not allocate matrix or linear solver')
@@ -1685,7 +1685,7 @@ cdef class IDA(BaseSundialsSolver):
                                          .format(flag))
                 elif linsolver == 'lapackband':
                     A = SUNBandMatrix(N, <int> opts['uband'], <int> opts['lband'], self.sunctx);
-                    LS = SUNLapackBand(self.y0, A)
+                    LS = SUNLinSol_LapackBand(self.y0, A, self.sunctx)
                     if (A == NULL or LS == NULL):
                         raise ValueError('Could not allocate matrix or linear solver')
                     flag = IDASetLinearSolver(ida_mem, LS, A)


### PR DESCRIPTION
Tested with scikits.odes 2.7.0 (at commit 57466a97a278f687a6b0a92343b767c495834b31), python 3.11.4, and sundials 6.6.1 compiled against oneMKL 2023.0 Update 2 on Ubuntu 22.04.3 LTS.  The test details below were taken from [this](https://github.com/bmcage/odes/issues/97#issuecomment-508741776) comment in #97:

<details>

<summary>Testing code and output w/ and w/o lapack</summary>

### With lapack
```
import numpy as np
from scikits.odes.odeint import odeint

tout = np.linspace(0, 1)
initial_values = np.array([1])

def right_hand_side(t, y, ydot):
    ydot[0] = y[0]

output = odeint(right_hand_side, tout, initial_values,linsolver='lapackdense')
print(output.values.y)
```
In a bash shell
```
export MKL_VERBOSE=1
ipython
<run code above>
MKL_VERBOSE oneMKL 2023.0 Update 2 Product build 20230613 for Intel(R) 64 architecture Intel(R) Advanced Vector Extensions 2 (Intel(R) AVX2) enabled processors, Lnx 1.90GHz lp64 gnu_thread
MKL_VERBOSE SDOT(2,0x562640d4f1a0,1,0x562640d4f1a0,1) 1.89ms CNR:OFF Dyn:1 FastMM:1 TID:0  NThr:2
... <lots of redacted MKL_VERBOSE and output.values.y output>
[2.66339741]
 [2.7183115 ]]
``` 
### With out lapack
```
import numpy as np
from scikits.odes.odeint import odeint

tout = np.linspace(0, 1)
initial_values = np.array([1])

def right_hand_side(t, y, ydot):
    ydot[0] = y[0]

output = odeint(right_hand_side, tout, initial_values,linsolver='dense')
print(output.values.y)
```
same bash shell/ipython session as above with lapack
```
... <lots of redacted output.values.y output and no MKL_VERBOSE output>
[2.66339741]
 [2.7183115 ]]
```
</details>