### PR TITLE
Add automatic upload to PyPI of releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+on:
+  release:
+    types:
+      - published
+
+name: release
+
+jobs:
+  pypi:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Install deps
+        run: python -m pip install -U build
+
+      - name: Setup dist
+        run: mkdir dist
+
+      - name: Build sdist
+        run: for f in packages/*; do python -m build --sdist $f; done
+
+      - name: Collect dists
+        run: cp packages/*/dist/* dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This should mean creating a GitHub release will cause this new workflow to run to use PyPI's trusted publishers.