### PR TITLE
Use fetch-depth: 0 to get tags

### DIFF
--- a/.github/workflows/test-overall.yml
+++ b/.github/workflows/test-overall.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-tags: true
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
For some reason checkout seems to ignore the option to fetch all tags...