### PR TITLE
Bump scikits-odes-daepack for auto-release test

### DIFF
--- a/packages/scikits-odes-daepack/meson.build
+++ b/packages/scikits-odes-daepack/meson.build
@@ -1,6 +1,6 @@
 project('scikits-odes-daepack',
   ['c', 'fortran'],
-  version : '0.1',
+  version : '0.2',
   meson_version: '>= 1.1.0',
   default_options : [
     'warning_level=1',

--- a/packages/scikits-odes-daepack/pyproject.toml
+++ b/packages/scikits-odes-daepack/pyproject.toml
@@ -4,7 +4,7 @@ requires = ['meson-python', 'numpy']
 
 [project]
 name = 'scikits-odes-daepack'
-version = "0.1"
+version = "0.2"
 description = 'Wrapper around daepack'
 readme = "README.md"
 authors = [


### PR DESCRIPTION
mesonpy lacks automatic version support, so update scikits-odes-daepack in prep for the test.