### PR TITLE
Add workflow to build binaries for scikits-odes-sundials

### DIFF
--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/__init__.py
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/__init__.py
@@ -4,14 +4,20 @@ SUNDIALS wrapper
 
 import inspect
 from . import _version
+from . import common_defs as _common
+
 __version__ = _version.get_versions()['version']
+
+SUNDIALS_VERSION = str(_common.sundials_version, 'utf-8')
 
 
 class CVODESolveException(Exception):
     """Base class for exceptions raised by ``CVODE.validate_flags``."""
+
     def __init__(self, soln):
         self.soln = soln
         self.args = (self._message.format(soln),)
+
 
 class CVODESolveFailed(CVODESolveException):
     """``CVODE.solve`` failed to reach endpoint"""
@@ -20,19 +26,24 @@ class CVODESolveFailed(CVODESolveException):
         "with values {0.errors.y}."
     )
 
+
 class CVODESolveFoundRoot(CVODESolveException):
     """``CVODE.solve`` found a root"""
     _message = "Solver found a root at {0.roots.t[0]}."
+
 
 class CVODESolveReachedTSTOP(CVODESolveException):
     """``CVODE.solve`` reached the endpoint specified by tstop."""
     _message = "Solver reached tstop at {0.tstop.t[0]}."
 
+
 class IDASolveException(Exception):
     """Base class for exceptions raised by ``IDA.validate_flags``."""
+
     def __init__(self, soln):
         self.soln = soln
         self.args = (self._message.format(soln),)
+
 
 class IDASolveFailed(IDASolveException):
     """``IDA.solve`` failed to reach endpoint"""
@@ -41,9 +52,11 @@ class IDASolveFailed(IDASolveException):
         "with values {0.errors.y} and derivatives {0.errors.ydot}."
     )
 
+
 class IDASolveFoundRoot(IDASolveException):
     """``IDA.solve`` found a root"""
     _message = "Solver found a root at {0.roots.t[0]}."
+
 
 class IDASolveReachedTSTOP(IDASolveException):
     """``IDA.solve`` reached the endpoint specified by tstop."""

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/__init__.py
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/__init__.py
@@ -3,12 +3,13 @@ SUNDIALS wrapper
 """
 
 import inspect
+
 from . import _version
-from . import common_defs as _common
+from . import common_defs
 
 __version__ = _version.get_versions()['version']
 
-SUNDIALS_VERSION = str(_common.sundials_version, 'utf-8')
+SUNDIALS_VERSION = str(common_defs.sundials_version, 'utf-8')
 
 
 class CVODESolveException(Exception):
@@ -76,3 +77,17 @@ def _get_num_args(func):
         if arg not in ("self", "cls"):
             arg_cnt += 1
     return arg_cnt
+
+
+from . import cvode
+from . import cvodes
+from . import ida
+from . import idas
+
+__all__ = [
+    'SUNDIALS_VERSION',
+    'cvode',
+    'cvodes',
+    'ida',
+    'idas',
+]

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_sundials.pxd
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_sundials.pxd
@@ -19,6 +19,9 @@ cdef extern from "sundials/sundials_context.h":
     int SUNContext_Free(SUNContext* ctx)
 
 cdef extern from "sundials/sundials_version.h":
+
+    # Expose SUNDIALS version as char
+    char *SUNDIALS_VERSION
     
     #Fill a string with SUNDIALS version information */
     int SUNDIALSGetVersion(char *version, int len)

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/common_defs.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/common_defs.pyx
@@ -6,7 +6,7 @@ import inspect
 from .c_sundials cimport (
     sunrealtype, sunindextype, N_Vector, SUNDlsMat, sunbooleantype,
     SUNMatrix, SUNMatGetID, SUNMATRIX_DENSE, SUNMATRIX_BAND, SUNMATRIX_SPARSE,
-    SUNMATRIX_CUSTOM,
+    SUNMATRIX_CUSTOM, SUNDIALS_VERSION,
 )
 from .c_nvector_serial cimport (
     N_VGetLength_Serial as nv_length_s, # use function not macro
@@ -21,6 +21,9 @@ from .c_sunmatrix cimport (
 from libc.stdio cimport stderr
 
 include "sundials_config.pxi"
+
+# Pull in SUNDIALS version
+sundials_version = SUNDIALS_VERSION
 
 precision = SUNDIALS_FLOAT_TYPE
 if SUNDIALS_FLOAT_TYPE == "single":

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/tests/test_solvers.py
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/tests/test_solvers.py
@@ -1,0 +1,63 @@
+import numpy as np
+import scikits_odes_sundials as sun
+
+
+def ode(t, y, yp):
+    yp[0] = 0.1
+    yp[1] = y[1]
+
+
+def dae(t, y, yp, res):
+    res[0] = yp[0] - 0.1
+    res[1] = 2*y[0] - y[1]
+
+
+def ode_solution(t, y0):
+    y = np.zeros([t.size, 2])
+    y[:, 0] = 0.1*t + y0[0]
+    y[:, 1] = y0[1]*np.exp(t)
+    return y
+
+
+def dae_solution(t, y0):
+    y = np.zeros([t.size, 2])
+    y[:, 0] = 0.1*t + y0[0]
+    y[:, 1] = 2*y[:, 0]
+    return y
+
+
+# common times and initial condition
+times = np.array([0, 5, 10])
+y0 = np.array([1, 2])
+
+
+# Testing cvode for ode
+solver = sun.cvode.CVODE(ode, rtol=1e-9, atol=1e-12)
+solution = solver.solve(times, y0)
+
+print("\nCVODE", "-"*10, solution, sep="\n")
+assert np.allclose(solution.values.y, ode_solution(times, y0))
+
+
+# Testing cvodes for ode
+solver = sun.cvodes.CVODES(ode, rtol=1e-9, atol=1e-12)
+solution = solver.solve(times, y0)
+
+print("\nCVODES", "-"*10, solution, sep="\n")
+assert np.allclose(solution.values.y, ode_solution(times, y0))
+
+
+# Testing ida for dae
+solver = sun.ida.IDA(dae, algebraic_vars_idx=[1], compute_initcond='yp0')
+solution = solver.solve(times, y0, [0, 0])
+
+print("\nIDA", "-"*10, solution, sep="\n")
+assert np.allclose(solution.values.y, dae_solution(times, y0))
+
+
+# Testing idas for dae
+solver = sun.idas.IDAS(dae, algebraic_vars_idx=[1], compute_initcond='yp0')
+solution = solver.solve(times, y0, [0, 0])
+
+print("\nIDAS", "-"*10, solution, sep="\n")
+assert np.allclose(solution.values.y, dae_solution(times, y0))


### PR DESCRIPTION
As mentioned in [issue #178](https://github.com/bmcage/odes/issues/178) the scikits-odes-sundials package can break when trying to build against incompatible versions of SUNDIALS. 

I suggested that one way to address this is to start building the binary wheel files for supported python versions and operating systems and uploading those, in addition to the tarbell, on pypi. The binary distributions would include a bundled SUNDIALS version that scikits-odes-sundials had already successfully been built with. This is how other packages with C and/or Fortran dependencies (numpy, scipy, etc.) distribute their packages.

In this pull request, I included the following changes:
1) Expose `SUNDIALS_VERSION` from `sundials_version.h` as a string to the Python package. This way, users can more easily tell which version of SUNDIALS was bundled/compiled in their installed scikits-odes-sundials package. 
2) I cleaned up the `__init__` file for scikits-odes-sundials by moving the exceptions into a new "hidden" module. Now that scikits-odes-sundials is loaded to pypi as a standalone package, there are benefits to installing it directly rather than through scikits-odes. Namely, if you only need the SUNDIALS wrapper, there is no longer a need to setup Fortran compilers, which are required for the full scikits-odes package due to daepack. A cleaner `__init__` file that imports relevant modules and "hides" exception classes makes sense for a package that can be installed independently.
3) I added a quick `test_solvers.py` function that is used to test CVODE, CVODES, IDA, and IDAS while the binary wheels files are being built.
4) I added a new workflow that can be used when releasing scikits-odes-sundials. The workflow runs through a matrix of python versions from 3.8 to 3.12 and includes all major operating systems and CPU architectures: MacOS x86-64, MacOS arm64, Windows x86-64, and Linux x86-64. The wheels files bundle official SUNDIALS releases taken from [conda-forge](https://anaconda.org/conda-forge/sundials). At the moment, this is the broadest range of operating systems and CPU architectures I can support through GitHub workflows based on which runners they have available.

I tested the full workflow and the resulting release using testpypi. You can see the results of the build workflow [here](https://github.com/c-randall/odes/actions/runs/10253618994) and the results from the tests [here](https://github.com/c-randall/testrepo). If you'd like to do any more testing or see the release, you can see the testpypi page [here](https://test.pypi.org/project/scikits-odes-sundials/). 

I have the new workflow, called `release-sundials.yml`, set to run only when triggered manually so you will have to change that over to `release` and update the upload information to go to pypi rather than testpypi when you are ready. 

If you are not interested in starting to distribute the binary files, please let me know. In that case I will likely make a new pypi project under a different name that I can try to keep linked to this repo, but that includes the binaries when releases are made, rather than just the tarbell. 

Some notes:
* Users can still install from the tarbell rather than from the binaries by running a command like `pip install --no-binary ...`. This preserves users' abilities to have full control over which SUNDIALS version they build with if they'd prefer to wrap a separate local version and not be forced into using the bundled version.
* The new workflow specifies 6.7 for the bundled SUNDIALS version, which is the greatest version that scikits-odes-sundials currently supports. Whenever scikits-odes-sundials is updated to work with SUNDIALS >= 7, the version in the workflow will need to be updated before the next release.
* I only built wheels for python versions >= 3.8 because that is inline with the currently supported versions shown [here](https://www.python.org/downloads/). Now that python is on a yearly release schedule, they are dropping support for an older version every October (this year 3.8 will lose support). I know the current scikits-odes documentation mentions working with versions >= 3.7, but this should probably be changed. Instead, releases should only be focused on supported versions.


