### PR TITLE
Add exception class declarations

### DIFF
--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_ida.pxd
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_ida.pxd
@@ -49,19 +49,19 @@ cdef extern from "ida/ida.h":
     enum: IDA_BAD_T           #-26
     enum: IDA_BAD_DKY         #-27
     enum: IDA_VECTOROP_ERR    #-28
-    
+
     enum: IDA_UNRECOGNIZED_ERROR #-99
 
     ctypedef int (*IDAResFn)(sunrealtype tt, N_Vector yy, N_Vector yp,
-                    N_Vector rr, void *user_data)
+                    N_Vector rr, void *user_data) except? -1
 
     ctypedef int (*IDARootFn)(sunrealtype t, N_Vector y, N_Vector yp,
-                    sunrealtype *gout, void *user_data)
+                    sunrealtype *gout, void *user_data) except? -1
 
     ctypedef int (*IDAEwtFn)(N_Vector y, N_Vector ewt, void *user_data)
 
-    ctypedef void (*IDAErrHandlerFn)(int error_code, const char *module, 
-                                    const char *function, char *msg, 
+    ctypedef void (*IDAErrHandlerFn)(int error_code, const char *module,
+                                    const char *function, char *msg,
                                     void *user_data)
 
     void *IDACreate(SUNContext sunctx)
@@ -74,7 +74,7 @@ cdef extern from "ida/ida.h":
     int IDASVtolerances(void *ida_mem, sunrealtype reltol, N_Vector abstol)
     int IDAWFtolerances(void *ida_mem, IDAEwtFn efun)
     int IDACalcIC(void *ida_mem, int icopt, sunrealtype tout1)
-    
+
     int IDASetNonlinConvCoefIC(void *ida_mem, sunrealtype epiccon)
     int IDASetMaxNumStepsIC(void *ida_mem, int maxnh)
     int IDASetMaxNumJacsIC(void *ida_mem, int maxnj)
@@ -82,7 +82,7 @@ cdef extern from "ida/ida.h":
     int IDASetLineSearchOffIC(void *ida_mem, sunbooleantype lsoff)
     int IDASetStepToleranceIC(void *ida_mem, sunrealtype steptol)
     int IDASetMaxBacksIC(void *ida_mem, int maxbacks)
-    
+
     int IDASetErrHandlerFn(void *ida_mem, IDAErrHandlerFn ehfun, void *eh_data)
     int IDASetErrFile(void *ida_mem, FILE *errfp)
     int IDASetUserData(void *ida_mem, void *user_data)
@@ -107,10 +107,10 @@ cdef extern from "ida/ida.h":
 
     int IDASolve(void *ida_mem, sunrealtype tout, sunrealtype *tret,
                  N_Vector yret, N_Vector ypret, int itask)
-    
+
     int IDAComputeY(void *ida_mem, N_Vector ycor, N_Vector y)
     int IDAComputeYp(void *ida_mem, N_Vector ycor, N_Vector yp)
-    
+
     int IDAGetDky(void *ida_mem, sunrealtype t, int k, N_Vector dky)
 
     int IDAGetWorkSpace(void *ida_mem, long int *lenrw, long int *leniw)
@@ -162,17 +162,17 @@ cdef extern from "ida/ida_ls.h":
     ctypedef int (*IDALsJacFn)(sunrealtype t, sunrealtype c_j, N_Vector y,
                                N_Vector yp, N_Vector r, SUNMatrix Jac,
                                void *user_data, N_Vector tmp1,
-                               N_Vector tmp2, N_Vector tmp3)
+                               N_Vector tmp2, N_Vector tmp3) except? -1
 
     ctypedef int (*IDALsPrecSetupFn)(sunrealtype tt, N_Vector yy,
                                     N_Vector yp, N_Vector rr,
-                                    sunrealtype c_j, void *user_data)
+                                    sunrealtype c_j, void *user_data) except? -1
 
     ctypedef int (*IDALsPrecSolveFn)(sunrealtype tt, N_Vector yy,
                                     N_Vector yp, N_Vector rr,
                                     N_Vector rvec, N_Vector zvec,
                                     sunrealtype c_j, sunrealtype delta,
-                                    void *user_data)
+                                    void *user_data) except? -1
 
     ctypedef int (*IDALsJacTimesSetupFn)(sunrealtype tt, N_Vector yy,
                                         N_Vector yp, N_Vector rr,
@@ -185,7 +185,7 @@ cdef extern from "ida/ida_ls.h":
                                       N_Vector tmp1, N_Vector tmp2) except? -1
 
     int IDASetLinearSolver(void *ida_mem, SUNLinearSolver LS, SUNMatrix A)
-    
+
     int IDASetJacFn(void *ida_mem, IDALsJacFn jac)
     int IDASetPreconditioner(void *ida_mem, IDALsPrecSetupFn pset,
                              IDALsPrecSolveFn psolve)
@@ -207,11 +207,11 @@ cdef extern from "ida/ida_ls.h":
     char *IDAGetLinReturnFlagName(long int flag)
 
 cdef extern from "ida/ida_direct.h":
-    
+
     ctypedef IDALsJacFn IDAJacFn
 
     int IDASetJacFn(void *ida_mem, IDAJacFn jac)
-    
+
     int IDAGetWorkSpace(void *ida_mem, long int *lenrwLS, long int *leniwLS)
     int IDAGetNumJacEvals(void *ida_mem, long int *njevals)
     int IDAGetNumResEvals(void *ida_mem, long int *nfevalsLS)

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
@@ -327,7 +327,7 @@ cdef class IDA_WrapJacRhsFunction(IDA_JacRhsFunction):
 
 cdef int _jacdense(sunrealtype tt, sunrealtype cj,
             N_Vector yy, N_Vector yp, N_Vector rr, SUNMatrix Jac,
-            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3):
+            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except? -1:
     """function with the signature of IDAJacFn """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp, residual_tmp
     cdef np.ndarray jac_tmp
@@ -413,7 +413,7 @@ cdef class IDA_WrapPrecSetupFunction(IDA_PrecSetupFunction):
 
 cdef int _prec_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr,
                        sunrealtype cj,
-                       void *auxiliary_data):
+                       void *auxiliary_data) except? -1:
     """ function with the signature of IDAPrecSetupFn, that calls
         the python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, rp_tmp, residual_tmp
@@ -499,7 +499,7 @@ cdef class IDA_WrapPrecSolveFunction(IDA_PrecSolveFunction):
 
 cdef int _prec_solvefn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector r,
                        N_Vector rvec, N_Vector z, sunrealtype cj,
-                       sunrealtype delta, void *auxiliary_data):
+                       sunrealtype delta, void *auxiliary_data) except? -1:
     """ function with the signature of CVodePrecSolveFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, r_tmp, z_tmp
 
@@ -610,7 +610,7 @@ cdef int _jac_times_vecfn(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, 
 
     if parallel_implementation:
         raise NotImplemented
-    
+
     yy_tmp = aux_data.yy_tmp
     yp_tmp = aux_data.yp_tmp
     rr_tmp = aux_data.residual_tmp
@@ -683,7 +683,7 @@ cdef class IDA_WrapJacTimesSetupFunction(IDA_JacTimesSetupFunction):
             user_flag = 0
         return user_flag
 
-cdef int _jac_times_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, 
+cdef int _jac_times_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr,
                             sunrealtype cj, void *user_data) except? -1:
     """ function with the signature of IDA_JacTimesSetupFunction, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp, rr_tmp
@@ -758,7 +758,7 @@ cdef class IDA_WrapErrHandler(IDA_ErrHandler):
 cdef void _ida_err_handler_fn(
     int error_code, const char *module, const char *function, char *msg,
     void *eh_data
-):
+) noexcept:
     """
     function with the signature of IDAErrHandlerFn, that calls python error
     handler
@@ -1072,10 +1072,10 @@ cdef class IDA:
                         yy is the current value of the dependent variable vector, y(t).
                         yp is the current value of ˙y(t).
                         rr is the current value of the residual vector F(t, y, y˙).
-                        v is the vector by which the Jacobian must be multiplied to 
+                        v is the vector by which the Jacobian must be multiplied to
                             the right.
                         Jv is the computed output vector.
-                        cj is the scalar in the system Jacobian, proportional to the 
+                        cj is the scalar in the system Jacobian, proportional to the
                             inverse of the step size.
                         user data is a pointer to user data (optional)
             'jac_times_setupfn':
@@ -1083,14 +1083,14 @@ cdef class IDA:
                 Description:
                     Optional. Default is to internal finite difference with no
                     extra setup.
-                    Defines a function that preprocesses and/or evaluates 
+                    Defines a function that preprocesses and/or evaluates
                     Jacobian-related data needed by the Jacobiantimes-vector routine
                     This function takes as input arguments:
                         tt is the current value of the independent variable.
                         yy is the current value of the dependent variable vector, y(t).
                         yp is the current value of ˙y(t).
                         rr is the current value of the residual vector F(t, y, y˙).
-                        cj is the scalar in the system Jacobian, proportional to the 
+                        cj is the scalar in the system Jacobian, proportional to the
                             inverse of the step size.
                         user data is a pointer to user data (optional)
             'err_handler':


### PR DESCRIPTION
Newer versions of cython complains if exception class declarations are not the same for ctypedef'd function pointers and cdef functions passed to such pointers.

Fixes:
https://github.com/bmcage/odes/issues/178#issuecomment-2295328057