### PR TITLE
Add exception class declarations

### DIFF
--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_ida.pxd
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/c_ida.pxd
@@ -49,19 +49,19 @@ cdef extern from "ida/ida.h":
     enum: IDA_BAD_T           #-26
     enum: IDA_BAD_DKY         #-27
     enum: IDA_VECTOROP_ERR    #-28
-    
+
     enum: IDA_UNRECOGNIZED_ERROR #-99
 
     ctypedef int (*IDAResFn)(sunrealtype tt, N_Vector yy, N_Vector yp,
-                    N_Vector rr, void *user_data)
+                    N_Vector rr, void *user_data) except? -1
 
     ctypedef int (*IDARootFn)(sunrealtype t, N_Vector y, N_Vector yp,
-                    sunrealtype *gout, void *user_data)
+                    sunrealtype *gout, void *user_data) except? -1
 
     ctypedef int (*IDAEwtFn)(N_Vector y, N_Vector ewt, void *user_data)
 
-    ctypedef void (*IDAErrHandlerFn)(int error_code, const char *module, 
-                                    const char *function, char *msg, 
+    ctypedef void (*IDAErrHandlerFn)(int error_code, const char *module,
+                                    const char *function, char *msg,
                                     void *user_data)
 
     void *IDACreate(SUNContext sunctx)
@@ -74,7 +74,7 @@ cdef extern from "ida/ida.h":
     int IDASVtolerances(void *ida_mem, sunrealtype reltol, N_Vector abstol)
     int IDAWFtolerances(void *ida_mem, IDAEwtFn efun)
     int IDACalcIC(void *ida_mem, int icopt, sunrealtype tout1)
-    
+
     int IDASetNonlinConvCoefIC(void *ida_mem, sunrealtype epiccon)
     int IDASetMaxNumStepsIC(void *ida_mem, int maxnh)
     int IDASetMaxNumJacsIC(void *ida_mem, int maxnj)
@@ -82,7 +82,7 @@ cdef extern from "ida/ida.h":
     int IDASetLineSearchOffIC(void *ida_mem, sunbooleantype lsoff)
     int IDASetStepToleranceIC(void *ida_mem, sunrealtype steptol)
     int IDASetMaxBacksIC(void *ida_mem, int maxbacks)
-    
+
     int IDASetErrHandlerFn(void *ida_mem, IDAErrHandlerFn ehfun, void *eh_data)
     int IDASetErrFile(void *ida_mem, FILE *errfp)
     int IDASetUserData(void *ida_mem, void *user_data)
@@ -107,10 +107,10 @@ cdef extern from "ida/ida.h":
 
     int IDASolve(void *ida_mem, sunrealtype tout, sunrealtype *tret,
                  N_Vector yret, N_Vector ypret, int itask)
-    
+
     int IDAComputeY(void *ida_mem, N_Vector ycor, N_Vector y)
     int IDAComputeYp(void *ida_mem, N_Vector ycor, N_Vector yp)
-    
+
     int IDAGetDky(void *ida_mem, sunrealtype t, int k, N_Vector dky)
 
     int IDAGetWorkSpace(void *ida_mem, long int *lenrw, long int *leniw)
@@ -162,17 +162,17 @@ cdef extern from "ida/ida_ls.h":
     ctypedef int (*IDALsJacFn)(sunrealtype t, sunrealtype c_j, N_Vector y,
                                N_Vector yp, N_Vector r, SUNMatrix Jac,
                                void *user_data, N_Vector tmp1,
-                               N_Vector tmp2, N_Vector tmp3)
+                               N_Vector tmp2, N_Vector tmp3) except? -1
 
     ctypedef int (*IDALsPrecSetupFn)(sunrealtype tt, N_Vector yy,
                                     N_Vector yp, N_Vector rr,
-                                    sunrealtype c_j, void *user_data)
+                                    sunrealtype c_j, void *user_data) except? -1
 
     ctypedef int (*IDALsPrecSolveFn)(sunrealtype tt, N_Vector yy,
                                     N_Vector yp, N_Vector rr,
                                     N_Vector rvec, N_Vector zvec,
                                     sunrealtype c_j, sunrealtype delta,
-                                    void *user_data)
+                                    void *user_data) except? -1
 
     ctypedef int (*IDALsJacTimesSetupFn)(sunrealtype tt, N_Vector yy,
                                         N_Vector yp, N_Vector rr,
@@ -185,7 +185,7 @@ cdef extern from "ida/ida_ls.h":
                                       N_Vector tmp1, N_Vector tmp2) except? -1
 
     int IDASetLinearSolver(void *ida_mem, SUNLinearSolver LS, SUNMatrix A)
-    
+
     int IDASetJacFn(void *ida_mem, IDALsJacFn jac)
     int IDASetPreconditioner(void *ida_mem, IDALsPrecSetupFn pset,
                              IDALsPrecSolveFn psolve)
@@ -205,6 +205,7 @@ cdef extern from "ida/ida_ls.h":
     int IDAGetNumLinResEvals(void *ida_mem, long int *nrevalsLS)
     int IDAGetLastLinFlag(void *ida_mem, long int *flag)
     char *IDAGetLinReturnFlagName(long int flag)
+
 
 cdef extern from "ida/ida_bbdpre.h":
 

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/cvode.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/cvode.pyx
@@ -334,7 +334,7 @@ cdef class CV_WrapJacRhsFunction(CV_JacRhsFunction):
 
 cdef int _jacdense(sunrealtype tt,
             N_Vector yy, N_Vector ff, SUNMatrix Jac,
-            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, 
+            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2,
             N_Vector tmp3) except? -1:
     """function with the signature of CVodeJacFn that calls python Jac
        Note: signature of Jac is SUNMatrix
@@ -421,8 +421,8 @@ class MutableBool(object):
     def __init__(self, value):
         self.value = value
 
-cdef int _prec_setupfn(sunrealtype tt, N_Vector yy, N_Vector ff, sunbooleantype jok, 
-                       sunbooleantype *jcurPtr, sunrealtype gamma, 
+cdef int _prec_setupfn(sunrealtype tt, N_Vector yy, N_Vector ff, sunbooleantype jok,
+                       sunbooleantype *jcurPtr, sunrealtype gamma,
                        void *auxiliary_data) except -1:
     """ function with the signature of CVLsPrecSetupFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp
@@ -437,7 +437,7 @@ cdef int _prec_setupfn(sunrealtype tt, N_Vector yy, N_Vector ff, sunbooleantype 
         nv_s2ndarray(yy, yy_tmp)
 
     jcurPtr_tmp = MutableBool(jcurPtr[0])
-    user_flag = aux_data.prec_setupfn.evaluate(tt, yy_tmp, jok, jcurPtr_tmp, 
+    user_flag = aux_data.prec_setupfn.evaluate(tt, yy_tmp, jok, jcurPtr_tmp,
                                                gamma, aux_data.user_data)
     jcurPtr[0] = jcurPtr_tmp.value
     return user_flag
@@ -503,8 +503,8 @@ cdef class CV_WrapPrecSolveFunction(CV_PrecSolveFunction):
             user_flag = 0
         return user_flag
 
-cdef int _prec_solvefn(sunrealtype tt, N_Vector yy, N_Vector ff, N_Vector r, 
-                       N_Vector z, sunrealtype gamma, sunrealtype delta, int lr, 
+cdef int _prec_solvefn(sunrealtype tt, N_Vector yy, N_Vector ff, N_Vector r,
+                       N_Vector z, sunrealtype gamma, sunrealtype delta, int lr,
                        void *auxiliary_data) except? -1:
     """ function with the signature of CVLsPrecSolveFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, r_tmp, z_tmp
@@ -714,7 +714,7 @@ def no_continue_fn(t, y, solver):
 cdef void _cv_err_handler_fn(
     int line, const char *func, const char *file, const char *msg,
     SUNErrCode err_code, void *err_user_data, SUNContext sunctx
-):
+) noexcept:
     """
     function with the signature of SUNErrHandlerFn, that calls python error
     handler
@@ -873,7 +873,7 @@ cdef class CVODE(BaseSundialsSolver):
                     Defines the jacobian function and has to be a subclass
                     of CV_JacRhsFunction class or python function. This function
                     takes as input arguments current time t, current value of y,
-                    current value of f(t,y), and 
+                    current value of f(t,y), and
                     a 2D numpy array of returned jacobian and optional userdata.
                     Return value is 0 if successfull.
                     Jacobian is only used for dense or lapackdense linear solver
@@ -925,12 +925,12 @@ cdef class CVODE(BaseSundialsSolver):
                                  For parallel implementation use_relaxation
                                  use lapackdense or lapackband respectively.
                     TODO: to add new solvers: pcg, spfgmr, superlumt, klu
-                    
+
             'nonlinsolver':
                 Values: 'newton' (= default), 'fixedpoint'
                 Description:
                     Specifies the used nonlinear solver.
-                    
+
             'lband', 'uband':
                 Values: non-negative integer, 0 = default
                 Description:
@@ -1664,7 +1664,7 @@ cdef class CVODE(BaseSundialsSolver):
                     'LinSolver: Unknown solver type {linsolver}'
                 )
         elif nonlinsolver == 'fixedpoint':
-            # create fixed point nonlinear solver object 
+            # create fixed point nonlinear solver object
             NLS = SUNNonlinSol_FixedPoint(self.y0, 0, self.sunctx);
             # attach nonlinear solver object to CVode
             flag = CVodeSetNonlinearSolver(cv_mem, NLS)

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pxd
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pxd
@@ -116,7 +116,9 @@ cdef class IDA_ContinuationFunction:
                        np.ndarray[DTYPE_t, ndim=1] ydot,
                        IDA solver)
 
-cdef int _res(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, void *self_obj)
+cdef int _res(
+    sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, void *self_obj
+) except? -1
 
 
 cdef class IDA_data(Shared_data):

--- a/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
+++ b/packages/scikits-odes-sundials/src/scikits_odes_sundials/ida.pyx
@@ -194,7 +194,7 @@ cdef class IDA_WrapRhsFunction(IDA_RhsFunction):
 
 
 cdef int _res(sunrealtype tt, N_Vector yy, N_Vector yp,
-              N_Vector rr, void *auxiliary_data):
+              N_Vector rr, void *auxiliary_data) except? -1:
     """ function with the signature of IDAResFn """
     cdef np.ndarray[DTYPE_t, ndim=1] residual_tmp, yy_tmp, yp_tmp
 
@@ -262,7 +262,7 @@ cdef class IDA_WrapRootFunction(IDA_RootFunction):
         return user_flag
 
 cdef int _rootfn(sunrealtype t, N_Vector yy, N_Vector yp,
-                 sunrealtype *gout, void *auxiliary_data):
+                 sunrealtype *gout, void *auxiliary_data) except? -1:
     """ function with the signature of IDARootFn """
 
     aux_data = <IDA_data> auxiliary_data
@@ -354,7 +354,7 @@ cdef class IDA_WrapJacRhsFunction(IDA_JacRhsFunction):
 
 cdef int _jacdense(sunrealtype tt, sunrealtype cj,
             N_Vector yy, N_Vector yp, N_Vector rr, SUNMatrix Jac,
-            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3):
+            void *auxiliary_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3) except? -1:
     """function with the signature of IDAJacFn """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp, residual_tmp
     cdef np.ndarray jac_tmp
@@ -440,7 +440,7 @@ cdef class IDA_WrapPrecSetupFunction(IDA_PrecSetupFunction):
 
 cdef int _prec_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr,
                        sunrealtype cj,
-                       void *auxiliary_data):
+                       void *auxiliary_data) except? -1:
     """ function with the signature of IDAPrecSetupFn, that calls
         the python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, rp_tmp, residual_tmp
@@ -526,7 +526,7 @@ cdef class IDA_WrapPrecSolveFunction(IDA_PrecSolveFunction):
 
 cdef int _prec_solvefn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector r,
                        N_Vector rvec, N_Vector z, sunrealtype cj,
-                       sunrealtype delta, void *auxiliary_data):
+                       sunrealtype delta, void *auxiliary_data) except? -1:
     """ function with the signature of CVodePrecSolveFn, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, r_tmp, z_tmp
 
@@ -637,7 +637,7 @@ cdef int _jac_times_vecfn(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, 
 
     if parallel_implementation:
         raise NotImplemented
-    
+
     yy_tmp = aux_data.yy_tmp
     yp_tmp = aux_data.yp_tmp
     rr_tmp = aux_data.residual_tmp
@@ -710,7 +710,7 @@ cdef class IDA_WrapJacTimesSetupFunction(IDA_JacTimesSetupFunction):
             user_flag = 0
         return user_flag
 
-cdef int _jac_times_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr, 
+cdef int _jac_times_setupfn(sunrealtype tt, N_Vector yy, N_Vector yp, N_Vector rr,
                             sunrealtype cj, void *user_data) except? -1:
     """ function with the signature of IDA_JacTimesSetupFunction, that calls python function """
     cdef np.ndarray[DTYPE_t, ndim=1] yy_tmp, yp_tmp, rr_tmp
@@ -755,7 +755,7 @@ def no_continue_fn(t, y, yp, solver):
 cdef void _ida_err_handler_fn(
     int line, const char *func, const char *file, const char *msg,
     SUNErrCode err_code, void *err_user_data, SUNContext sunctx
-):
+) noexcept:
     """
     function with the signature of SUNErrHandlerFn, that calls python error
     handler
@@ -1067,10 +1067,10 @@ cdef class IDA(BaseSundialsSolver):
                         yy is the current value of the dependent variable vector, y(t).
                         yp is the current value of ˙y(t).
                         rr is the current value of the residual vector F(t, y, y˙).
-                        v is the vector by which the Jacobian must be multiplied to 
+                        v is the vector by which the Jacobian must be multiplied to
                             the right.
                         Jv is the computed output vector.
-                        cj is the scalar in the system Jacobian, proportional to the 
+                        cj is the scalar in the system Jacobian, proportional to the
                             inverse of the step size.
                         user data is a pointer to user data (optional)
             'jac_times_setupfn':
@@ -1078,14 +1078,14 @@ cdef class IDA(BaseSundialsSolver):
                 Description:
                     Optional. Default is to internal finite difference with no
                     extra setup.
-                    Defines a function that preprocesses and/or evaluates 
+                    Defines a function that preprocesses and/or evaluates
                     Jacobian-related data needed by the Jacobiantimes-vector routine
                     This function takes as input arguments:
                         tt is the current value of the independent variable.
                         yy is the current value of the dependent variable vector, y(t).
                         yp is the current value of ˙y(t).
                         rr is the current value of the residual vector F(t, y, y˙).
-                        cj is the scalar in the system Jacobian, proportional to the 
+                        cj is the scalar in the system Jacobian, proportional to the
                             inverse of the step size.
                         user data is a pointer to user data (optional)
             'err_handler':


### PR DESCRIPTION
Newer versions of cython complains if exception class declarations are not the same for ctypedef'd function pointers and cdef functions passed to such pointers.

Rebased version of #186.