### PR TITLE
Skip release uploads if file exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,7 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+          verbose: true
+          print-hash: true


### PR DESCRIPTION
This means we don't need to do extra work to check scikits-odes-daepack if we don't change it.