### PR TITLE
Fix linking errors on Windows builds by adding sundials_core library

### DIFF
--- a/packages/scikits-odes-sundials/setup_build.py
+++ b/packages/scikits-odes-sundials/setup_build.py
@@ -273,6 +273,9 @@ class build_ext(_build_ext):
                         pass
                 except ImportError:
                     info("pkgconfig module not found, using preset paths")
+                    
+            # SUNDIALS core types/context, needed starting with 7.0
+            SUNDIALS_LIBRARIES.append('sundials_core') 
 
             # This is where to put N_vector codes (currently only serial is
             # supported)


### PR DESCRIPTION
Builds for `v3.1` fail on Windows due to linking errors:

```
common_defs.obj : error LNK2001: unresolved external symbol __imp_SUNContext_Free
common_defs.obj : error LNK2001: unresolved external symbol __imp_SUNContext_Create
common_defs.obj : error LNK2001: unresolved external symbol __imp_SUNMatGetID
```

Adding the `sundials_core` library to `SUNDIALS_LIBRARIES` during the build fixes the linking errors. This fix has been successfully tested on my local machine (Windows 10, Python 3.12, SUNDIALS 7.2, and Visual Studio's compilers).


