### PR TITLE
Add Windows/MacOS to test-sundials CI

### DIFF
--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -129,13 +129,14 @@ jobs:
         TOXENV: ${{ matrix.tox-env }}
 
   test-windows:
-    name: (Test ${{ matrix.python-version }}, ${{ matrix.os }})
+    name: tests (${{ matrix.python-version }}, ${{matrix.sundials-version}}, ${{ matrix.os }}, double, 32)
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         os: [macos-latest, windows-latest]  # set more OS here, if desired
         python-version: ["3.9", "3.13"]  # set more python versions here, if desired
+        sundials-version: ["7.1.1"]  # set more SUNDIALS version here, if desired
         
     defaults:
       run:
@@ -154,7 +155,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup SUNDIALS
-        run: conda install sundials=7.1.1 -c conda-forge  # SUNDIALS version is set here
+        run: conda install sundials=${{ matrix.sundials-version }} -c conda-forge
 
       - name: Verify environment
         run: |
@@ -164,10 +165,13 @@ jobs:
       - name: Set SUNDIALS installation path
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            echo "SUNDIALS_INST=%CONDA_PREFIX%/Library" >> $GITHUB_ENV
+            SUNDIALS_INST="$CONDA_PREFIX\Library"
           else
-            echo "SUNDIALS_INST=$CONDA_PREFIX" >> $GITHUB_ENV
+            SUNDIALS_INST="$CONDA_PREFIX"
           fi
+
+          echo "SUNDIALS_INST is set to: $SUNDIALS_INST"
+          echo "SUNDIALS_INST=$SUNDIALS_INST" >> $GITHUB_ENV
 
       - name: Install scikits-odes-sundials
         working-directory: packages/scikits-odes-sundials

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -192,6 +192,6 @@ jobs:
                 
       - name: Run tests
         working-directory: packages/scikits-odes-sundials
-        run: tox
+        run: tox || tox --recreate
         env:
           TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -134,9 +134,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]  # set more OS here, if desired
-        python-version: ["3.9", "3.13"]  # set more python versions here, if desired
-        sundials-version: ["7.1.1"]  # set more SUNDIALS version here, if desired
+        os: [windows-latest, macos-latest, macos-13]
+        sundials-version: ["7.1.1"]
+        include:
+          - python-version: "3.9"
+            tox-env: py39
+          - python-version: "3.13"
+            tox-env: py313
         
     defaults:
       run:
@@ -173,11 +177,10 @@ jobs:
           echo "SUNDIALS_INST is set to: $SUNDIALS_INST"
           echo "SUNDIALS_INST=$SUNDIALS_INST" >> $GITHUB_ENV
 
-      - name: Install scikits-odes-sundials
-        working-directory: packages/scikits-odes-sundials
+      - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
+          python -m pip install --upgrade tox
 
       - name: List info
         run: |
@@ -185,7 +188,7 @@ jobs:
           conda list
                 
       - name: Run tests
-        working-directory: packages/scikits-odes-sundials/src/scikits_odes_sundials
-        run: |
-          pip install pytest
-          pytest .
+        working-directory: packages/scikits-odes-sundials
+        run: tox
+        env:
+          TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -135,6 +135,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, macos-13]
+        python-version: ["3.9", "3.13"]
         sundials-version: ["7.1.1"]
         include:
           - python-version: "3.9"

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -171,7 +171,7 @@ jobs:
           conda info
           conda list
 
-      - name: Set SUNDIALS installation path
+      - name: Set SUNDIALS and SSL paths
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             SUNDIALS_INST="$CONDA_PREFIX\Library"
@@ -181,6 +181,9 @@ jobs:
 
           echo "SUNDIALS_INST is set to: $SUNDIALS_INST"
           echo "SUNDIALS_INST=$SUNDIALS_INST" >> $GITHUB_ENV
+
+          echo "SSL_CERT_FILE is at: $SSL_CERT_FILE"
+          echo "SSL_CERT_FILE=$SSL_CERT_FILE" >> $GITHUB_ENV
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -143,6 +143,9 @@ jobs:
             tox-env: py39
           - python-version: "3.13"
             tox-env: py313
+        exclude:
+          - os: windows-latest  # Issue with tox venv, cannot access openssl
+            python-version: "3.9"
         
     defaults:
       run:
@@ -183,9 +186,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
-
-      - name: Get tox
-        run: conda install tox
+          python -m pip install --upgrade tox
 
       - name: List info
         run: |

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -183,7 +183,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
-          python -m pip install --upgrade tox
+
+      - name: Get tox
+        run: conda install tox
 
       - name: List info
         run: |
@@ -192,6 +194,6 @@ jobs:
                 
       - name: Run tests
         working-directory: packages/scikits-odes-sundials
-        run: tox || tox --recreate
+        run: tox
         env:
           TOXENV: ${{ matrix.tox-env }}

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -143,9 +143,9 @@ jobs:
             tox-env: py39
           - python-version: "3.13"
             tox-env: py313
-        # exclude:
-        #   - os: windows-latest  # Issue with tox venv, pip has no ssl access
-        #     python-version: "3.9"
+        exclude:
+          - os: windows-latest  # Issue with tox venv, pip has no ssl access
+            python-version: "3.9"
         
     defaults:
       run:
@@ -171,7 +171,7 @@ jobs:
           conda info
           conda list
 
-      - name: Set SUNDIALS and SSL paths
+      - name: Set SUNDIALS path
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             SUNDIALS_INST="$CONDA_PREFIX\Library"
@@ -181,9 +181,6 @@ jobs:
 
           echo "SUNDIALS_INST is set to: $SUNDIALS_INST"
           echo "SUNDIALS_INST=$SUNDIALS_INST" >> $GITHUB_ENV
-
-          echo "SSL_CERT_FILE is at: $SSL_CERT_FILE"
-          echo "SSL_CERT_FILE=$SSL_CERT_FILE" >> $GITHUB_ENV
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -127,3 +127,61 @@ jobs:
         tox
       env:
         TOXENV: ${{ matrix.tox-env }}
+
+  test-windows:
+    name: (Test ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]  # set more OS here, if desired
+        python-version: ["3.9", "3.13"]  # set more python versions here, if desired
+        
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup conda/python
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          miniconda-version: latest
+          activate-environment: odes
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup SUNDIALS
+        run: conda install sundials=7.1.1 -c conda-forge  # SUNDIALS version is set here
+
+      - name: Verify environment
+        run: |
+          conda info
+          conda list
+
+      - name: Set SUNDIALS installation path
+        run: |
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            echo "SUNDIALS_INST=%CONDA_PREFIX%/Library" >> $GITHUB_ENV
+          else
+            echo "SUNDIALS_INST=$CONDA_PREFIX" >> $GITHUB_ENV
+          fi
+
+      - name: Install scikits-odes-sundials
+        working-directory: packages/scikits-odes-sundials
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: List info
+        run: |
+          conda info
+          conda list
+                
+      - name: Run tests
+        working-directory: packages/scikits-odes-sundials/src/scikits_odes_sundials
+        run: |
+          pip install pytest
+          pytest .

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -143,9 +143,9 @@ jobs:
             tox-env: py39
           - python-version: "3.13"
             tox-env: py313
-        exclude:
-          - os: windows-latest  # Issue with tox venv, cannot access openssl
-            python-version: "3.9"
+        # exclude:
+        #   - os: windows-latest  # Issue with tox venv, pip has no ssl access
+        #     python-version: "3.9"
         
     defaults:
       run:

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -133,6 +133,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, macos-13]
         python-version: ["3.9", "3.13"]
@@ -181,6 +182,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
           python -m pip install --upgrade tox
 
       - name: List info

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -128,7 +128,7 @@ jobs:
       env:
         TOXENV: ${{ matrix.tox-env }}
 
-  test-windows:
+  tests-win-mac:
     name: tests (${{ matrix.python-version }}, ${{matrix.sundials-version}}, ${{ matrix.os }}, double, 32)
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test-sundials.yml
+++ b/.github/workflows/test-sundials.yml
@@ -143,9 +143,6 @@ jobs:
             tox-env: py39
           - python-version: "3.13"
             tox-env: py313
-        exclude:
-          - os: windows-latest  # Issue with tox venv, pip has no ssl access
-            python-version: "3.9"
         
     defaults:
       run:
@@ -155,21 +152,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup conda/python
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Setup Python and SUNDIALS
+        uses: mamba-org/setup-micromamba@v2
         with:
-          auto-update-conda: true
-          miniconda-version: latest
-          activate-environment: odes
-          python-version: ${{ matrix.python-version }}
-
-      - name: Setup SUNDIALS
-        run: conda install sundials=${{ matrix.sundials-version }} -c conda-forge
+          environment-name: odes
+          create-args: >-
+            python=${{ matrix.python-version }}
+            sundials=${{ matrix.sundials-version }}
+          condarc: |
+            channels:
+              - conda-forge
 
       - name: Verify environment
         run: |
-          conda info
-          conda list
+          micromamba info
+          micromamba list
 
       - name: Set SUNDIALS path
         run: |
@@ -190,8 +187,8 @@ jobs:
 
       - name: List info
         run: |
-          conda info
-          conda list
+          micromamba info
+          micromamba list
                 
       - name: Run tests
         working-directory: packages/scikits-odes-sundials

--- a/packages/scikits-odes-sundials/tox.ini
+++ b/packages/scikits-odes-sundials/tox.ini
@@ -13,6 +13,7 @@ passenv=
     CPATH
     PIP_VERBOSE
     PYTHONFAULTHANDLER
+    SSL_CERT_FILE
 deps =
     pytest
     -r local-requirements.txt

--- a/packages/scikits-odes-sundials/tox.ini
+++ b/packages/scikits-odes-sundials/tox.ini
@@ -4,6 +4,7 @@ setenv = LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 [testenv]
 passenv=
+    SUNDIALS_INST
     SUNDIALS_DIR
     SUNDIALS_LIBDIR
     SUNDIALS_INCLUDEDIR

--- a/packages/scikits-odes-sundials/tox.ini
+++ b/packages/scikits-odes-sundials/tox.ini
@@ -13,7 +13,6 @@ passenv=
     CPATH
     PIP_VERBOSE
     PYTHONFAULTHANDLER
-    SSL_CERT_FILE
 deps =
     pytest
     -r local-requirements.txt


### PR DESCRIPTION
This PR adds a build-and-test routine to `test-sundials.yml` for both Windows and MacOS to improve catching breaking changes on various operating systems, as suggested in PR #196.

## Notes:
- I'm not aware of a convenient way to build SUNDIALS using a variety of precisions and index sizes on Windows or MacOS, so I used builds from `conda-forge` (double precision, 32-bit index).
- You may want to consider adding `macos-13` to the `matrix.os` section. `macos-latest` uses arm64 architectures and `macos-13` uses x86_64, so testing both would likely be more robust.
- I only added Python 3.9 and 3.13 to the `matrix.python-version` section since those are the oldest and newest versions that are currently supported. Feel free to add more.

## Comments:
I noticed that the tests inside `packages/scikits-odes-sundials/src/scikits_odes_sundials` only test the `_get_num_args` function, so the tests here are not particularly robust. Now that `scikits-odes-sundials` can be distributed as its own package, it may be worth moving over some of the more rigorous tests that are specific to `odes-sundials` from `packages/scikits-odes/src/scikits/odes/tests`.