### PR TITLE
Force C compiler to the C17 standard

### DIFF
--- a/packages/scikits-odes-daepack/meson.build
+++ b/packages/scikits-odes-daepack/meson.build
@@ -4,7 +4,8 @@ project('scikits-odes-daepack',
   meson_version: '>= 1.1.0',
   default_options : [
     'warning_level=1',
-    'buildtype=release'
+    'buildtype=release',
+    'c_std=c17',
   ])
 
 py = import('python').find_installation(pure: false)


### PR DESCRIPTION
Recent versions of gcc default to C23, but the code produced by f2py is currently not compatible with this newer standard.