### PR TITLE
Avoid implicit array -> scalar conversion in tests (numpy 2.4)

### DIFF
--- a/packages/scikits-odes/src/scikits/odes/tests/test_user_return_vals_cvode.py
+++ b/packages/scikits-odes/src/scikits/odes/tests/test_user_return_vals_cvode.py
@@ -8,7 +8,7 @@ def normal_rhs(t, y, ydot):
     ydot[0] = t
 
 def complex_rhs(t, y, ydot):
-    ydot[0] = t - y
+    ydot[0] = t - y[0]
 
 def rhs_with_return(t, y, ydot):
     ydot[0] = t

--- a/packages/scikits-odes/src/scikits/odes/tests/test_user_return_vals_ida.py
+++ b/packages/scikits-odes/src/scikits/odes/tests/test_user_return_vals_ida.py
@@ -5,17 +5,17 @@ from .. import dae
 from ..sundials.ida import StatusEnumIDA
 
 def normal_rhs(t, y, ydot, res):
-    res[0] = ydot - t
+    res[0] = ydot[0] - t
 
 def complex_rhs(t, y, ydot, res):
-    res[0] = ydot - t + y
+    res[0] = ydot[0] - t + y[0]
 
 def rhs_with_return(t, y, ydot, res):
-    res[0] = ydot - t
+    res[0] = ydot[0] - t
     return 0
 
 def rhs_problem_late(t, y, ydot, res):
-    res[0] = ydot - t
+    res[0] = ydot[0] - t
     if t > 0.5:
         return 1
 
@@ -23,7 +23,7 @@ def rhs_problem_immediate(t, y, ydot, res):
     return 1
 
 def rhs_error_late(t, y, ydot, res):
-    res[0] = ydot - t
+    res[0] = ydot[0] - t
     if t > 0.5:
         return -1
 


### PR DESCRIPTION
Many tests fail with numpy 2.4

```
_____________________ TestCVodeReturn.test_jac_error_late ______________________
TypeError: only 0-dimensional arrays can be converted to Python scalars

The above exception was the direct cause of the following exception:

self = <odes.tests.test_user_return_vals_cvode.TestCVodeReturn testMethod=test_jac_error_late>

    def test_jac_error_late(self):
        solver = ode(self.solvername, complex_rhs, jacfn=jac_error_late, old_api=False)
>       soln = solver.solve([0, 1], [1])
               ^^^^^^^^^^^^^^^^^^^^^^^^^

src/scikits/odes/tests/test_user_return_vals_cvode.py:243:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/nix/store/wyl71rbgix5j7lm559zm79raxwdif8fk-python3.13-scikits.odes-3.1.1/lib/python3.13/site-packages/scikits_odes/ode.py:177: in solve
    return self._integrator.solve(tspan, y0)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/scikits_odes_sundials/cvode.pyx:1819: in scikits_odes_sundials.cvode.CVODE.solve
    ???
src/scikits_odes_sundials/cvode.pyx:1857: in scikits_odes_sundials.cvode.CVODE._solve
    ???
src/scikits_odes_sundials/cvode.pyx:1383: in scikits_odes_sundials.cvode.CVODE._init_step
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

t = 0.0, y = array([1.]), ydot = array([1.])

    def complex_rhs(t, y, ydot):
>       ydot[0] = t - y
        ^^^^^^^
E       ValueError: setting an array element with a sequence.

src/scikits/odes/tests/test_user_return_vals_cvode.py:11: ValueError
```

This patch fixes the problem by using `array[0]` explicitly.